### PR TITLE
Fix layout and use scaling by font everywhere

### DIFF
--- a/Dependencies/WinFormsColor/Source/WinFormsColor/ColorPanel.cs
+++ b/Dependencies/WinFormsColor/Source/WinFormsColor/ColorPanel.cs
@@ -429,5 +429,11 @@ public class ColorPanel : UserControl
     private bool ShouldSerializeTopLeftColor() => designSerializeColor;
     private bool ShouldSerializeTopRightColor() => designSerializeColor;
     private bool ShouldSerializeBottomLeftColor() => designSerializeColor;
+
+    private void InitializeComponent()
+    {
+
+    }
+
     private bool ShouldSerializeBottomRightColor() => designSerializeColor;
 }

--- a/Dependencies/WinFormsColor/Source/WinFormsColor/ColorPanel.resx
+++ b/Dependencies/WinFormsColor/Source/WinFormsColor/ColorPanel.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/Dependencies/WinFormsColor/Source/WinFormsColor/ColorPickerPanel.designer.cs
+++ b/Dependencies/WinFormsColor/Source/WinFormsColor/ColorPickerPanel.designer.cs
@@ -66,29 +66,29 @@ partial class ColorPickerPanel
         // 
         // radioHue
         // 
-        this.radioHue.Anchor = System.Windows.Forms.AnchorStyles.Right;
+        this.radioHue.Anchor = System.Windows.Forms.AnchorStyles.Left;
         this.radioHue.AutoSize = true;
         this.radioHue.Checked = true;
         this.radioHue.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.radioHue.Location = new System.Drawing.Point(3, 4);
-        this.radioHue.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
+        this.radioHue.Location = new System.Drawing.Point(34, 5);
+        this.radioHue.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
         this.radioHue.Name = "radioHue";
-        this.radioHue.Size = new System.Drawing.Size(33, 17);
+        this.radioHue.Size = new System.Drawing.Size(34, 19);
         this.radioHue.TabIndex = 0;
         this.radioHue.TabStop = true;
         this.radioHue.Text = "H";
         this.radioHue.UseVisualStyleBackColor = true;
-        this.radioHue.CheckedChanged += new System.EventHandler(this.RadioHue_CheckedChanged);
+        this.radioHue.CheckedChanged += this.RadioHue_CheckedChanged;
         // 
         // radioSaturation
         // 
-        this.radioSaturation.Anchor = System.Windows.Forms.AnchorStyles.Right;
+        this.radioSaturation.Anchor = System.Windows.Forms.AnchorStyles.Left;
         this.radioSaturation.AutoSize = true;
         this.radioSaturation.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.radioSaturation.Location = new System.Drawing.Point(4, 27);
-        this.radioSaturation.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
+        this.radioSaturation.Location = new System.Drawing.Point(34, 34);
+        this.radioSaturation.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
         this.radioSaturation.Name = "radioSaturation";
-        this.radioSaturation.Size = new System.Drawing.Size(32, 17);
+        this.radioSaturation.Size = new System.Drawing.Size(31, 19);
         this.radioSaturation.TabIndex = 2;
         this.radioSaturation.Text = "S";
         this.radioSaturation.UseVisualStyleBackColor = true;
@@ -96,13 +96,13 @@ partial class ColorPickerPanel
         // 
         // radioValue
         // 
-        this.radioValue.Anchor = System.Windows.Forms.AnchorStyles.Right;
+        this.radioValue.Anchor = System.Windows.Forms.AnchorStyles.Left;
         this.radioValue.AutoSize = true;
         this.radioValue.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.radioValue.Location = new System.Drawing.Point(4, 50);
-        this.radioValue.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
+        this.radioValue.Location = new System.Drawing.Point(34, 63);
+        this.radioValue.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
         this.radioValue.Name = "radioValue";
-        this.radioValue.Size = new System.Drawing.Size(32, 17);
+        this.radioValue.Size = new System.Drawing.Size(32, 19);
         this.radioValue.TabIndex = 4;
         this.radioValue.Text = "V";
         this.radioValue.UseVisualStyleBackColor = true;
@@ -110,13 +110,13 @@ partial class ColorPickerPanel
         // 
         // radioRed
         // 
-        this.radioRed.Anchor = System.Windows.Forms.AnchorStyles.Right;
+        this.radioRed.Anchor = System.Windows.Forms.AnchorStyles.Left;
         this.radioRed.AutoSize = true;
         this.radioRed.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.radioRed.Location = new System.Drawing.Point(113, 4);
-        this.radioRed.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
+        this.radioRed.Location = new System.Drawing.Point(149, 5);
+        this.radioRed.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
         this.radioRed.Name = "radioRed";
-        this.radioRed.Size = new System.Drawing.Size(33, 17);
+        this.radioRed.Size = new System.Drawing.Size(32, 19);
         this.radioRed.TabIndex = 6;
         this.radioRed.Text = "R";
         this.radioRed.UseVisualStyleBackColor = true;
@@ -124,13 +124,13 @@ partial class ColorPickerPanel
         // 
         // radioBlue
         // 
-        this.radioBlue.Anchor = System.Windows.Forms.AnchorStyles.Right;
+        this.radioBlue.Anchor = System.Windows.Forms.AnchorStyles.Left;
         this.radioBlue.AutoSize = true;
         this.radioBlue.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.radioBlue.Location = new System.Drawing.Point(114, 50);
-        this.radioBlue.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
+        this.radioBlue.Location = new System.Drawing.Point(149, 63);
+        this.radioBlue.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
         this.radioBlue.Name = "radioBlue";
-        this.radioBlue.Size = new System.Drawing.Size(32, 17);
+        this.radioBlue.Size = new System.Drawing.Size(32, 19);
         this.radioBlue.TabIndex = 10;
         this.radioBlue.Text = "B";
         this.radioBlue.UseVisualStyleBackColor = true;
@@ -138,13 +138,13 @@ partial class ColorPickerPanel
         // 
         // radioGreen
         // 
-        this.radioGreen.Anchor = System.Windows.Forms.AnchorStyles.Right;
+        this.radioGreen.Anchor = System.Windows.Forms.AnchorStyles.Left;
         this.radioGreen.AutoSize = true;
         this.radioGreen.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.radioGreen.Location = new System.Drawing.Point(113, 27);
-        this.radioGreen.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
+        this.radioGreen.Location = new System.Drawing.Point(149, 34);
+        this.radioGreen.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
         this.radioGreen.Name = "radioGreen";
-        this.radioGreen.Size = new System.Drawing.Size(33, 17);
+        this.radioGreen.Size = new System.Drawing.Size(33, 19);
         this.radioGreen.TabIndex = 8;
         this.radioGreen.Text = "G";
         this.radioGreen.UseVisualStyleBackColor = true;
@@ -152,39 +152,23 @@ partial class ColorPickerPanel
         // 
         // numHue
         // 
-        this.numHue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-        this.numHue.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.numHue.Increment = new decimal(new int[] {
-        15,
-        0,
-        0,
-        0});
-        this.numHue.Location = new System.Drawing.Point(42, 3);
-        this.numHue.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
-        this.numHue.Maximum = new decimal(new int[] {
-        360,
-        0,
-        0,
-        0});
+        this.numHue.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+        this.numHue.Increment = new decimal(new int[] { 15, 0, 0, 0 });
+        this.numHue.Location = new System.Drawing.Point(74, 3);
+        this.numHue.Maximum = new decimal(new int[] { 360, 0, 0, 0 });
         this.numHue.Name = "numHue";
-        this.numHue.Size = new System.Drawing.Size(65, 20);
+        this.numHue.Size = new System.Drawing.Size(65, 23);
         this.numHue.TabIndex = 1;
         this.numHue.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
         this.numHue.ValueChanged += new System.EventHandler(this.NumHue_ValueChanged);
         // 
         // numSaturation
         // 
-        this.numSaturation.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-        this.numSaturation.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.numSaturation.Increment = new decimal(new int[] {
-        5,
-        0,
-        0,
-        0});
-        this.numSaturation.Location = new System.Drawing.Point(42, 26);
-        this.numSaturation.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
+        this.numSaturation.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+        this.numSaturation.Increment = new decimal(new int[] { 5, 0, 0, 0 });
+        this.numSaturation.Location = new System.Drawing.Point(74, 32);
         this.numSaturation.Name = "numSaturation";
-        this.numSaturation.Size = new System.Drawing.Size(65, 20);
+        this.numSaturation.Size = new System.Drawing.Size(65, 23);
         this.numSaturation.TabIndex = 3;
         this.numSaturation.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
         this.numSaturation.ValueChanged += new System.EventHandler(this.NumSaturation_ValueChanged);
@@ -192,33 +176,21 @@ partial class ColorPickerPanel
         // numValue
         // 
         this.numValue.Anchor = System.Windows.Forms.AnchorStyles.Left;
-        this.numValue.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.numValue.Increment = new decimal(new int[] {
-        5,
-        0,
-        0,
-        0});
-        this.numValue.Location = new System.Drawing.Point(42, 49);
-        this.numValue.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
+        this.numValue.Increment = new decimal(new int[] { 5, 0, 0, 0 });
+        this.numValue.Location = new System.Drawing.Point(74, 61);
         this.numValue.Name = "numValue";
-        this.numValue.Size = new System.Drawing.Size(65, 20);
+        this.numValue.Size = new System.Drawing.Size(65, 23);
         this.numValue.TabIndex = 5;
         this.numValue.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
         this.numValue.ValueChanged += new System.EventHandler(this.NumValue_ValueChanged);
         // 
         // numRed
         // 
-        this.numRed.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-        this.numRed.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.numRed.Location = new System.Drawing.Point(152, 3);
-        this.numRed.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
-        this.numRed.Maximum = new decimal(new int[] {
-        255,
-        0,
-        0,
-        0});
+        this.numRed.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+        this.numRed.Location = new System.Drawing.Point(188, 3);
+        this.numRed.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
         this.numRed.Name = "numRed";
-        this.numRed.Size = new System.Drawing.Size(65, 20);
+        this.numRed.Size = new System.Drawing.Size(65, 23);
         this.numRed.TabIndex = 7;
         this.numRed.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
         this.numRed.ValueChanged += new System.EventHandler(this.NumRed_ValueChanged);
@@ -227,32 +199,21 @@ partial class ColorPickerPanel
         // 
         this.numGreen.Anchor = System.Windows.Forms.AnchorStyles.Left;
         this.numGreen.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.numGreen.Location = new System.Drawing.Point(152, 26);
-        this.numGreen.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
-        this.numGreen.Maximum = new decimal(new int[] {
-        255,
-        0,
-        0,
-        0});
+        this.numGreen.Location = new System.Drawing.Point(188, 32);
+        this.numGreen.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
         this.numGreen.Name = "numGreen";
-        this.numGreen.Size = new System.Drawing.Size(65, 20);
+        this.numGreen.Size = new System.Drawing.Size(65, 23);
         this.numGreen.TabIndex = 9;
         this.numGreen.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
         this.numGreen.ValueChanged += new System.EventHandler(this.NumGreen_ValueChanged);
         // 
         // numBlue
         // 
-        this.numBlue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-        this.numBlue.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.numBlue.Location = new System.Drawing.Point(152, 49);
-        this.numBlue.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
-        this.numBlue.Maximum = new decimal(new int[] {
-        255,
-        0,
-        0,
-        0});
+        this.numBlue.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+        this.numBlue.Location = new System.Drawing.Point(188, 61);
+        this.numBlue.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
         this.numBlue.Name = "numBlue";
-        this.numBlue.Size = new System.Drawing.Size(65, 20);
+        this.numBlue.Size = new System.Drawing.Size(65, 23);
         this.numBlue.TabIndex = 11;
         this.numBlue.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
         this.numBlue.ValueChanged += new System.EventHandler(this.NumBlue_ValueChanged);
@@ -262,29 +223,29 @@ partial class ColorPickerPanel
         this.labelHex.Anchor = System.Windows.Forms.AnchorStyles.Right;
         this.labelHex.AutoSize = true;
         this.labelHex.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.labelHex.Location = new System.Drawing.Point(227, 52);
-        this.labelHex.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
+        this.labelHex.Location = new System.Drawing.Point(271, 65);
+        this.labelHex.Margin = new System.Windows.Forms.Padding(8, 0, 3, 0);
         this.labelHex.Name = "labelHex";
-        this.labelHex.Size = new System.Drawing.Size(30, 13);
+        this.labelHex.Size = new System.Drawing.Size(31, 15);
         this.labelHex.TabIndex = 14;
         this.labelHex.Text = "Web";
+        this.labelHex.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
         // 
         // labelAlpha
         // 
         this.labelAlpha.Anchor = System.Windows.Forms.AnchorStyles.Right;
         this.labelAlpha.AutoSize = true;
         this.labelAlpha.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.labelAlpha.Location = new System.Drawing.Point(223, 6);
-        this.labelAlpha.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
+        this.labelAlpha.Location = new System.Drawing.Point(264, 7);
+        this.labelAlpha.Margin = new System.Windows.Forms.Padding(8, 0, 3, 0);
         this.labelAlpha.Name = "labelAlpha";
-        this.labelAlpha.Size = new System.Drawing.Size(34, 13);
+        this.labelAlpha.Size = new System.Drawing.Size(38, 15);
         this.labelAlpha.TabIndex = 12;
         this.labelAlpha.Text = "Alpha";
+        this.labelAlpha.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
         // 
         // TableTop
         // 
-        this.TableTop.AutoSize = true;
-        this.TableTop.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
         this.TableTop.ColumnCount = 6;
         this.TableTop.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
         this.TableTop.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
@@ -301,7 +262,7 @@ partial class ColorPickerPanel
         this.TableTop.Name = "TableTop";
         this.TableTop.RowCount = 1;
         this.TableTop.RowStyles.Add(new System.Windows.Forms.RowStyle());
-        this.TableTop.Size = new System.Drawing.Size(363, 187);
+        this.TableTop.Size = new System.Drawing.Size(400, 187);
         this.TableTop.TabIndex = 1;
         // 
         // tableLayoutPanel3
@@ -314,25 +275,23 @@ partial class ColorPickerPanel
         this.tableLayoutPanel3.Controls.Add(this.colorShowBox, 0, 1);
         this.tableLayoutPanel3.Controls.Add(this.label2, 0, 2);
         this.tableLayoutPanel3.Controls.Add(this.label1, 0, 0);
-        this.tableLayoutPanel3.Location = new System.Drawing.Point(289, 42);
+        this.tableLayoutPanel3.Location = new System.Drawing.Point(308, 40);
         this.tableLayoutPanel3.MinimumSize = new System.Drawing.Size(64, 102);
         this.tableLayoutPanel3.Name = "tableLayoutPanel3";
         this.tableLayoutPanel3.RowCount = 3;
         this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
         this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 64F));
         this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-        this.tableLayoutPanel3.Size = new System.Drawing.Size(64, 102);
+        this.tableLayoutPanel3.Size = new System.Drawing.Size(64, 106);
         this.tableLayoutPanel3.TabIndex = 9;
         // 
         // colorShowBox
         // 
-        this.colorShowBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-        | System.Windows.Forms.AnchorStyles.Left)
-        | System.Windows.Forms.AnchorStyles.Right)));
+        this.colorShowBox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
         this.colorShowBox.AutoSize = true;
         this.colorShowBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
         this.colorShowBox.Color = System.Drawing.Color.DarkRed;
-        this.colorShowBox.Location = new System.Drawing.Point(3, 22);
+        this.colorShowBox.Location = new System.Drawing.Point(3, 24);
         this.colorShowBox.LowerColor = System.Drawing.Color.Maroon;
         this.colorShowBox.Name = "colorShowBox";
         this.colorShowBox.Padding = new System.Windows.Forms.Padding(0, 3, 0, 3);
@@ -346,10 +305,10 @@ partial class ColorPickerPanel
         this.label2.Anchor = System.Windows.Forms.AnchorStyles.None;
         this.label2.AutoSize = true;
         this.label2.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.label2.Location = new System.Drawing.Point(11, 86);
+        this.label2.Location = new System.Drawing.Point(8, 88);
         this.label2.Margin = new System.Windows.Forms.Padding(3);
         this.label2.Name = "label2";
-        this.label2.Size = new System.Drawing.Size(41, 13);
+        this.label2.Size = new System.Drawing.Size(47, 15);
         this.label2.TabIndex = 4;
         this.label2.Text = "Current";
         this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -359,10 +318,10 @@ partial class ColorPickerPanel
         this.label1.Anchor = System.Windows.Forms.AnchorStyles.None;
         this.label1.AutoSize = true;
         this.label1.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.label1.Location = new System.Drawing.Point(20, 3);
+        this.label1.Location = new System.Drawing.Point(19, 3);
         this.label1.Margin = new System.Windows.Forms.Padding(3);
         this.label1.Name = "label1";
-        this.label1.Size = new System.Drawing.Size(23, 13);
+        this.label1.Size = new System.Drawing.Size(26, 15);
         this.label1.TabIndex = 3;
         this.label1.Text = "Old";
         this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -372,7 +331,7 @@ partial class ColorPickerPanel
         this.colorPanel.Anchor = System.Windows.Forms.AnchorStyles.None;
         this.colorPanel.BottomLeftColor = System.Drawing.Color.Black;
         this.colorPanel.BottomRightColor = System.Drawing.Color.Black;
-        this.colorPanel.Location = new System.Drawing.Point(9, 6);
+        this.colorPanel.Location = new System.Drawing.Point(28, 6);
         this.colorPanel.Name = "colorPanel";
         this.colorPanel.Size = new System.Drawing.Size(198, 175);
         this.colorPanel.TabIndex = 0;
@@ -382,8 +341,8 @@ partial class ColorPickerPanel
         // 
         // colorSlider
         // 
-        this.colorSlider.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)));
-        this.colorSlider.Location = new System.Drawing.Point(213, 3);
+        this.colorSlider.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom;
+        this.colorSlider.Location = new System.Drawing.Point(232, 3);
         this.colorSlider.Name = "colorSlider";
         this.colorSlider.ShowInnerPicker = false;
         this.colorSlider.Size = new System.Drawing.Size(32, 181);
@@ -392,8 +351,8 @@ partial class ColorPickerPanel
         // 
         // alphaSlider
         // 
-        this.alphaSlider.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)));
-        this.alphaSlider.Location = new System.Drawing.Point(251, 3);
+        this.alphaSlider.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom;
+        this.alphaSlider.Location = new System.Drawing.Point(270, 3);
         this.alphaSlider.Maximum = System.Drawing.Color.White;
         this.alphaSlider.Minimum = System.Drawing.Color.Transparent;
         this.alphaSlider.Name = "alphaSlider";
@@ -404,98 +363,87 @@ partial class ColorPickerPanel
         // 
         // TableBottom
         // 
-        this.TableBottom.AutoSize = true;
-        this.TableBottom.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-        this.TableBottom.ColumnCount = 7;
+        this.TableBottom.ColumnCount = 8;
+        this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
         this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
         this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
         this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
         this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
         this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
         this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-        this.TableBottom.Controls.Add(this.textBoxHex, 5, 2);
-        this.TableBottom.Controls.Add(this.labelHex, 4, 2);
-        this.TableBottom.Controls.Add(this.numAlpha, 5, 0);
-        this.TableBottom.Controls.Add(this.numGreen, 3, 1);
-        this.TableBottom.Controls.Add(this.labelAlpha, 4, 0);
-        this.TableBottom.Controls.Add(this.radioBlue, 2, 2);
-        this.TableBottom.Controls.Add(this.numBlue, 3, 2);
-        this.TableBottom.Controls.Add(this.radioGreen, 2, 1);
-        this.TableBottom.Controls.Add(this.numRed, 3, 0);
-        this.TableBottom.Controls.Add(this.radioRed, 2, 0);
-        this.TableBottom.Controls.Add(this.numValue, 1, 2);
-        this.TableBottom.Controls.Add(this.radioValue, 0, 2);
-        this.TableBottom.Controls.Add(this.numSaturation, 1, 1);
-        this.TableBottom.Controls.Add(this.radioSaturation, 0, 1);
-        this.TableBottom.Controls.Add(this.radioHue, 0, 0);
-        this.TableBottom.Controls.Add(this.numHue, 1, 0);
+        this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+        this.TableBottom.Controls.Add(this.textBoxHex, 6, 2);
+        this.TableBottom.Controls.Add(this.labelHex, 5, 2);
+        this.TableBottom.Controls.Add(this.numAlpha, 6, 0);
+        this.TableBottom.Controls.Add(this.numGreen, 4, 1);
+        this.TableBottom.Controls.Add(this.labelAlpha, 5, 0);
+        this.TableBottom.Controls.Add(this.radioBlue, 3, 2);
+        this.TableBottom.Controls.Add(this.numBlue, 4, 2);
+        this.TableBottom.Controls.Add(this.radioGreen, 3, 1);
+        this.TableBottom.Controls.Add(this.numRed, 4, 0);
+        this.TableBottom.Controls.Add(this.radioRed, 3, 0);
+        this.TableBottom.Controls.Add(this.numValue, 2, 2);
+        this.TableBottom.Controls.Add(this.radioValue, 1, 2);
+        this.TableBottom.Controls.Add(this.numSaturation, 2, 1);
+        this.TableBottom.Controls.Add(this.radioSaturation, 1, 1);
+        this.TableBottom.Controls.Add(this.radioHue, 1, 0);
+        this.TableBottom.Controls.Add(this.numHue, 2, 0);
         this.TableBottom.Dock = System.Windows.Forms.DockStyle.Fill;
         this.TableBottom.Location = new System.Drawing.Point(0, 187);
         this.TableBottom.Name = "TableBottom";
+        this.TableBottom.Padding = new System.Windows.Forms.Padding(3, 0, 0, 0);
         this.TableBottom.RowCount = 4;
         this.TableBottom.RowStyles.Add(new System.Windows.Forms.RowStyle());
         this.TableBottom.RowStyles.Add(new System.Windows.Forms.RowStyle());
         this.TableBottom.RowStyles.Add(new System.Windows.Forms.RowStyle());
         this.TableBottom.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-        this.TableBottom.Size = new System.Drawing.Size(363, 88);
+        this.TableBottom.Size = new System.Drawing.Size(400, 88);
         this.TableBottom.TabIndex = 0;
         // 
         // textBoxHex
         // 
-        this.textBoxHex.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-        this.textBoxHex.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.textBoxHex.Location = new System.Drawing.Point(263, 49);
-        this.textBoxHex.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
+        this.textBoxHex.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+        this.textBoxHex.Location = new System.Drawing.Point(308, 61);
         this.textBoxHex.Name = "textBoxHex";
-        this.textBoxHex.Size = new System.Drawing.Size(65, 20);
+        this.textBoxHex.Size = new System.Drawing.Size(65, 23);
         this.textBoxHex.TabIndex = 15;
         this.textBoxHex.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
         this.textBoxHex.TextChanged += new System.EventHandler(this.TextBoxHex_TextChanged);
         // 
         // numAlpha
         // 
-        this.numAlpha.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-        this.numAlpha.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.numAlpha.Location = new System.Drawing.Point(263, 3);
-        this.numAlpha.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
-        this.numAlpha.Maximum = new decimal(new int[] {
-        255,
-        0,
-        0,
-        0});
+        this.numAlpha.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+        this.numAlpha.Location = new System.Drawing.Point(308, 3);
+        this.numAlpha.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
         this.numAlpha.Name = "numAlpha";
-        this.numAlpha.Size = new System.Drawing.Size(65, 20);
+        this.numAlpha.Size = new System.Drawing.Size(65, 23);
         this.numAlpha.TabIndex = 13;
         this.numAlpha.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
         this.numAlpha.ValueChanged += new System.EventHandler(this.NumAlpha_ValueChanged);
         // 
         // ColorPickerPanel
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.Controls.Add(this.TableBottom);
         this.Controls.Add(this.TableTop);
         this.Name = "ColorPickerPanel";
-        this.Size = new System.Drawing.Size(363, 275);
-        ((System.ComponentModel.ISupportInitialize)(this.numHue)).EndInit();
-        ((System.ComponentModel.ISupportInitialize)(this.numSaturation)).EndInit();
-        ((System.ComponentModel.ISupportInitialize)(this.numValue)).EndInit();
-        ((System.ComponentModel.ISupportInitialize)(this.numRed)).EndInit();
-        ((System.ComponentModel.ISupportInitialize)(this.numGreen)).EndInit();
-        ((System.ComponentModel.ISupportInitialize)(this.numBlue)).EndInit();
+        this.Size = new System.Drawing.Size(400, 275);
+        ((System.ComponentModel.ISupportInitialize)this.numHue).EndInit();
+        ((System.ComponentModel.ISupportInitialize)this.numSaturation).EndInit();
+        ((System.ComponentModel.ISupportInitialize)this.numValue).EndInit();
+        ((System.ComponentModel.ISupportInitialize)this.numRed).EndInit();
+        ((System.ComponentModel.ISupportInitialize)this.numGreen).EndInit();
+        ((System.ComponentModel.ISupportInitialize)this.numBlue).EndInit();
         this.TableTop.ResumeLayout(false);
         this.TableTop.PerformLayout();
         this.tableLayoutPanel3.ResumeLayout(false);
         this.tableLayoutPanel3.PerformLayout();
         this.TableBottom.ResumeLayout(false);
         this.TableBottom.PerformLayout();
-        ((System.ComponentModel.ISupportInitialize)(this.numAlpha)).EndInit();
+        ((System.ComponentModel.ISupportInitialize)this.numAlpha).EndInit();
         this.ResumeLayout(false);
-        this.PerformLayout();
-
     }
-
 
     private System.Windows.Forms.RadioButton radioHue;
     private System.Windows.Forms.RadioButton radioSaturation;

--- a/Dependencies/WinFormsColor/Source/WinFormsColor/ColorPickerPanel.designer.cs
+++ b/Dependencies/WinFormsColor/Source/WinFormsColor/ColorPickerPanel.designer.cs
@@ -26,54 +26,54 @@ partial class ColorPickerPanel
     /// </summary>
     private void InitializeComponent()
     {
-        System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ColorPickerPanel));
-        this.radioHue = new System.Windows.Forms.RadioButton();
-        this.radioSaturation = new System.Windows.Forms.RadioButton();
-        this.radioValue = new System.Windows.Forms.RadioButton();
-        this.radioRed = new System.Windows.Forms.RadioButton();
-        this.radioBlue = new System.Windows.Forms.RadioButton();
-        this.radioGreen = new System.Windows.Forms.RadioButton();
-        this.numHue = new System.Windows.Forms.NumericUpDown();
-        this.numSaturation = new System.Windows.Forms.NumericUpDown();
-        this.numValue = new System.Windows.Forms.NumericUpDown();
-        this.numRed = new System.Windows.Forms.NumericUpDown();
-        this.numGreen = new System.Windows.Forms.NumericUpDown();
-        this.numBlue = new System.Windows.Forms.NumericUpDown();
-        this.labelHex = new System.Windows.Forms.Label();
-        this.labelAlpha = new System.Windows.Forms.Label();
-        this.TableTop = new System.Windows.Forms.TableLayoutPanel();
-        this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-        this.colorShowBox = new Fetze.WinFormsColor.ColorShowBox();
-        this.label2 = new System.Windows.Forms.Label();
-        this.label1 = new System.Windows.Forms.Label();
-        this.colorPanel = new Fetze.WinFormsColor.ColorPanel();
-        this.colorSlider = new Fetze.WinFormsColor.ColorSlider();
-        this.alphaSlider = new Fetze.WinFormsColor.ColorSlider();
-        this.TableBottom = new System.Windows.Forms.TableLayoutPanel();
-        this.textBoxHex = new System.Windows.Forms.TextBox();
-        this.numAlpha = new System.Windows.Forms.NumericUpDown();
-        ((System.ComponentModel.ISupportInitialize)(this.numHue)).BeginInit();
-        ((System.ComponentModel.ISupportInitialize)(this.numSaturation)).BeginInit();
-        ((System.ComponentModel.ISupportInitialize)(this.numValue)).BeginInit();
-        ((System.ComponentModel.ISupportInitialize)(this.numRed)).BeginInit();
-        ((System.ComponentModel.ISupportInitialize)(this.numGreen)).BeginInit();
-        ((System.ComponentModel.ISupportInitialize)(this.numBlue)).BeginInit();
+        var resources = new System.ComponentModel.ComponentResourceManager(typeof(ColorPickerPanel));
+        this.radioHue = new RadioButton();
+        this.radioSaturation = new RadioButton();
+        this.radioValue = new RadioButton();
+        this.radioRed = new RadioButton();
+        this.radioBlue = new RadioButton();
+        this.radioGreen = new RadioButton();
+        this.numHue = new NumericUpDown();
+        this.numSaturation = new NumericUpDown();
+        this.numValue = new NumericUpDown();
+        this.numRed = new NumericUpDown();
+        this.numGreen = new NumericUpDown();
+        this.numBlue = new NumericUpDown();
+        this.labelHex = new Label();
+        this.labelAlpha = new Label();
+        this.TableTop = new TableLayoutPanel();
+        this.tableLayoutPanel3 = new TableLayoutPanel();
+        this.colorShowBox = new ColorShowBox();
+        this.label2 = new Label();
+        this.label1 = new Label();
+        this.colorPanel = new ColorPanel();
+        this.colorSlider = new ColorSlider();
+        this.alphaSlider = new ColorSlider();
+        this.TableBottom = new TableLayoutPanel();
+        this.textBoxHex = new TextBox();
+        this.numAlpha = new NumericUpDown();
+        ((System.ComponentModel.ISupportInitialize)this.numHue).BeginInit();
+        ((System.ComponentModel.ISupportInitialize)this.numSaturation).BeginInit();
+        ((System.ComponentModel.ISupportInitialize)this.numValue).BeginInit();
+        ((System.ComponentModel.ISupportInitialize)this.numRed).BeginInit();
+        ((System.ComponentModel.ISupportInitialize)this.numGreen).BeginInit();
+        ((System.ComponentModel.ISupportInitialize)this.numBlue).BeginInit();
         this.TableTop.SuspendLayout();
         this.tableLayoutPanel3.SuspendLayout();
         this.TableBottom.SuspendLayout();
-        ((System.ComponentModel.ISupportInitialize)(this.numAlpha)).BeginInit();
+        ((System.ComponentModel.ISupportInitialize)this.numAlpha).BeginInit();
         this.SuspendLayout();
         // 
         // radioHue
         // 
-        this.radioHue.Anchor = System.Windows.Forms.AnchorStyles.Left;
+        this.radioHue.Anchor = AnchorStyles.Left;
         this.radioHue.AutoSize = true;
         this.radioHue.Checked = true;
-        this.radioHue.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.radioHue.Location = new System.Drawing.Point(34, 5);
-        this.radioHue.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+        this.radioHue.ImeMode = ImeMode.NoControl;
+        this.radioHue.Location = new Point(34, 5);
+        this.radioHue.Margin = new Padding(7, 3, 3, 3);
         this.radioHue.Name = "radioHue";
-        this.radioHue.Size = new System.Drawing.Size(34, 19);
+        this.radioHue.Size = new Size(34, 19);
         this.radioHue.TabIndex = 0;
         this.radioHue.TabStop = true;
         this.radioHue.Text = "H";
@@ -82,296 +82,304 @@ partial class ColorPickerPanel
         // 
         // radioSaturation
         // 
-        this.radioSaturation.Anchor = System.Windows.Forms.AnchorStyles.Left;
+        this.radioSaturation.Anchor = AnchorStyles.Left;
         this.radioSaturation.AutoSize = true;
-        this.radioSaturation.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.radioSaturation.Location = new System.Drawing.Point(34, 34);
-        this.radioSaturation.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+        this.radioSaturation.ImeMode = ImeMode.NoControl;
+        this.radioSaturation.Location = new Point(34, 34);
+        this.radioSaturation.Margin = new Padding(7, 3, 3, 3);
         this.radioSaturation.Name = "radioSaturation";
-        this.radioSaturation.Size = new System.Drawing.Size(31, 19);
+        this.radioSaturation.Size = new Size(31, 19);
         this.radioSaturation.TabIndex = 2;
         this.radioSaturation.Text = "S";
         this.radioSaturation.UseVisualStyleBackColor = true;
-        this.radioSaturation.CheckedChanged += new System.EventHandler(this.RadioSaturation_CheckedChanged);
+        this.radioSaturation.CheckedChanged += this.RadioSaturation_CheckedChanged;
         // 
         // radioValue
         // 
-        this.radioValue.Anchor = System.Windows.Forms.AnchorStyles.Left;
+        this.radioValue.Anchor = AnchorStyles.Left;
         this.radioValue.AutoSize = true;
-        this.radioValue.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.radioValue.Location = new System.Drawing.Point(34, 63);
-        this.radioValue.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+        this.radioValue.ImeMode = ImeMode.NoControl;
+        this.radioValue.Location = new Point(34, 63);
+        this.radioValue.Margin = new Padding(7, 3, 3, 3);
         this.radioValue.Name = "radioValue";
-        this.radioValue.Size = new System.Drawing.Size(32, 19);
+        this.radioValue.Size = new Size(32, 19);
         this.radioValue.TabIndex = 4;
         this.radioValue.Text = "V";
         this.radioValue.UseVisualStyleBackColor = true;
-        this.radioValue.CheckedChanged += new System.EventHandler(this.RadioValue_CheckedChanged);
+        this.radioValue.CheckedChanged += this.RadioValue_CheckedChanged;
         // 
         // radioRed
         // 
-        this.radioRed.Anchor = System.Windows.Forms.AnchorStyles.Left;
+        this.radioRed.Anchor = AnchorStyles.Left;
         this.radioRed.AutoSize = true;
-        this.radioRed.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.radioRed.Location = new System.Drawing.Point(149, 5);
-        this.radioRed.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+        this.radioRed.ImeMode = ImeMode.NoControl;
+        this.radioRed.Location = new Point(149, 5);
+        this.radioRed.Margin = new Padding(7, 3, 3, 3);
         this.radioRed.Name = "radioRed";
-        this.radioRed.Size = new System.Drawing.Size(32, 19);
+        this.radioRed.Size = new Size(32, 19);
         this.radioRed.TabIndex = 6;
         this.radioRed.Text = "R";
         this.radioRed.UseVisualStyleBackColor = true;
-        this.radioRed.CheckedChanged += new System.EventHandler(this.RadioRed_CheckedChanged);
+        this.radioRed.CheckedChanged += this.RadioRed_CheckedChanged;
         // 
         // radioBlue
         // 
-        this.radioBlue.Anchor = System.Windows.Forms.AnchorStyles.Left;
+        this.radioBlue.Anchor = AnchorStyles.Left;
         this.radioBlue.AutoSize = true;
-        this.radioBlue.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.radioBlue.Location = new System.Drawing.Point(149, 63);
-        this.radioBlue.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+        this.radioBlue.ImeMode = ImeMode.NoControl;
+        this.radioBlue.Location = new Point(149, 63);
+        this.radioBlue.Margin = new Padding(7, 3, 3, 3);
         this.radioBlue.Name = "radioBlue";
-        this.radioBlue.Size = new System.Drawing.Size(32, 19);
+        this.radioBlue.Size = new Size(32, 19);
         this.radioBlue.TabIndex = 10;
         this.radioBlue.Text = "B";
         this.radioBlue.UseVisualStyleBackColor = true;
-        this.radioBlue.CheckedChanged += new System.EventHandler(this.RadioBlue_CheckedChanged);
+        this.radioBlue.CheckedChanged += this.RadioBlue_CheckedChanged;
         // 
         // radioGreen
         // 
-        this.radioGreen.Anchor = System.Windows.Forms.AnchorStyles.Left;
+        this.radioGreen.Anchor = AnchorStyles.Left;
         this.radioGreen.AutoSize = true;
-        this.radioGreen.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.radioGreen.Location = new System.Drawing.Point(149, 34);
-        this.radioGreen.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+        this.radioGreen.ImeMode = ImeMode.NoControl;
+        this.radioGreen.Location = new Point(149, 34);
+        this.radioGreen.Margin = new Padding(7, 3, 3, 3);
         this.radioGreen.Name = "radioGreen";
-        this.radioGreen.Size = new System.Drawing.Size(33, 19);
+        this.radioGreen.Size = new Size(33, 19);
         this.radioGreen.TabIndex = 8;
         this.radioGreen.Text = "G";
         this.radioGreen.UseVisualStyleBackColor = true;
-        this.radioGreen.CheckedChanged += new System.EventHandler(this.RadioGreen_CheckedChanged);
+        this.radioGreen.CheckedChanged += this.RadioGreen_CheckedChanged;
         // 
         // numHue
         // 
-        this.numHue.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+        this.numHue.Anchor = AnchorStyles.None;
         this.numHue.Increment = new decimal(new int[] { 15, 0, 0, 0 });
-        this.numHue.Location = new System.Drawing.Point(74, 3);
+        this.numHue.Location = new Point(74, 3);
         this.numHue.Maximum = new decimal(new int[] { 360, 0, 0, 0 });
         this.numHue.Name = "numHue";
-        this.numHue.Size = new System.Drawing.Size(65, 23);
+        this.numHue.Size = new Size(65, 23);
         this.numHue.TabIndex = 1;
-        this.numHue.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-        this.numHue.ValueChanged += new System.EventHandler(this.NumHue_ValueChanged);
+        this.numHue.TextAlign = HorizontalAlignment.Right;
+        this.numHue.ValueChanged += this.NumHue_ValueChanged;
         // 
         // numSaturation
         // 
-        this.numSaturation.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+        this.numSaturation.Anchor = AnchorStyles.None;
         this.numSaturation.Increment = new decimal(new int[] { 5, 0, 0, 0 });
-        this.numSaturation.Location = new System.Drawing.Point(74, 32);
+        this.numSaturation.Location = new Point(74, 32);
         this.numSaturation.Name = "numSaturation";
-        this.numSaturation.Size = new System.Drawing.Size(65, 23);
+        this.numSaturation.Size = new Size(65, 23);
         this.numSaturation.TabIndex = 3;
-        this.numSaturation.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-        this.numSaturation.ValueChanged += new System.EventHandler(this.NumSaturation_ValueChanged);
+        this.numSaturation.TextAlign = HorizontalAlignment.Right;
+        this.numSaturation.ValueChanged += this.NumSaturation_ValueChanged;
         // 
         // numValue
         // 
-        this.numValue.Anchor = System.Windows.Forms.AnchorStyles.Left;
+        this.numValue.Anchor = AnchorStyles.None;
         this.numValue.Increment = new decimal(new int[] { 5, 0, 0, 0 });
-        this.numValue.Location = new System.Drawing.Point(74, 61);
+        this.numValue.Location = new Point(74, 61);
         this.numValue.Name = "numValue";
-        this.numValue.Size = new System.Drawing.Size(65, 23);
+        this.numValue.Size = new Size(65, 23);
         this.numValue.TabIndex = 5;
-        this.numValue.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-        this.numValue.ValueChanged += new System.EventHandler(this.NumValue_ValueChanged);
+        this.numValue.TextAlign = HorizontalAlignment.Right;
+        this.numValue.ValueChanged += this.NumValue_ValueChanged;
         // 
         // numRed
         // 
-        this.numRed.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-        this.numRed.Location = new System.Drawing.Point(188, 3);
+        this.numRed.Anchor = AnchorStyles.None;
+        this.numRed.Location = new Point(188, 3);
         this.numRed.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
         this.numRed.Name = "numRed";
-        this.numRed.Size = new System.Drawing.Size(65, 23);
+        this.numRed.Size = new Size(65, 23);
         this.numRed.TabIndex = 7;
-        this.numRed.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-        this.numRed.ValueChanged += new System.EventHandler(this.NumRed_ValueChanged);
+        this.numRed.TextAlign = HorizontalAlignment.Right;
+        this.numRed.ValueChanged += this.NumRed_ValueChanged;
         // 
         // numGreen
         // 
-        this.numGreen.Anchor = System.Windows.Forms.AnchorStyles.Left;
-        this.numGreen.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.numGreen.Location = new System.Drawing.Point(188, 32);
+        this.numGreen.Anchor = AnchorStyles.None;
+        this.numGreen.BorderStyle = BorderStyle.FixedSingle;
+        this.numGreen.Location = new Point(188, 32);
         this.numGreen.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
         this.numGreen.Name = "numGreen";
-        this.numGreen.Size = new System.Drawing.Size(65, 23);
+        this.numGreen.Size = new Size(65, 23);
         this.numGreen.TabIndex = 9;
-        this.numGreen.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-        this.numGreen.ValueChanged += new System.EventHandler(this.NumGreen_ValueChanged);
+        this.numGreen.TextAlign = HorizontalAlignment.Right;
+        this.numGreen.ValueChanged += this.NumGreen_ValueChanged;
         // 
         // numBlue
         // 
-        this.numBlue.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-        this.numBlue.Location = new System.Drawing.Point(188, 61);
+        this.numBlue.Anchor = AnchorStyles.None;
+        this.numBlue.Location = new Point(188, 61);
         this.numBlue.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
         this.numBlue.Name = "numBlue";
-        this.numBlue.Size = new System.Drawing.Size(65, 23);
+        this.numBlue.Size = new Size(65, 23);
         this.numBlue.TabIndex = 11;
-        this.numBlue.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-        this.numBlue.ValueChanged += new System.EventHandler(this.NumBlue_ValueChanged);
+        this.numBlue.TextAlign = HorizontalAlignment.Right;
+        this.numBlue.ValueChanged += this.NumBlue_ValueChanged;
         // 
         // labelHex
         // 
-        this.labelHex.Anchor = System.Windows.Forms.AnchorStyles.Right;
+        this.labelHex.Anchor = AnchorStyles.Right;
         this.labelHex.AutoSize = true;
-        this.labelHex.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.labelHex.Location = new System.Drawing.Point(271, 65);
-        this.labelHex.Margin = new System.Windows.Forms.Padding(8, 0, 3, 0);
+        this.labelHex.ImeMode = ImeMode.NoControl;
+        this.labelHex.Location = new Point(271, 65);
+        this.labelHex.Margin = new Padding(8, 0, 3, 0);
         this.labelHex.Name = "labelHex";
-        this.labelHex.Size = new System.Drawing.Size(31, 15);
+        this.labelHex.Size = new Size(31, 15);
         this.labelHex.TabIndex = 14;
         this.labelHex.Text = "Web";
-        this.labelHex.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+        this.labelHex.TextAlign = ContentAlignment.MiddleRight;
         // 
         // labelAlpha
         // 
-        this.labelAlpha.Anchor = System.Windows.Forms.AnchorStyles.Right;
+        this.labelAlpha.Anchor = AnchorStyles.Right;
         this.labelAlpha.AutoSize = true;
-        this.labelAlpha.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.labelAlpha.Location = new System.Drawing.Point(264, 7);
-        this.labelAlpha.Margin = new System.Windows.Forms.Padding(8, 0, 3, 0);
+        this.labelAlpha.ImeMode = ImeMode.NoControl;
+        this.labelAlpha.Location = new Point(264, 7);
+        this.labelAlpha.Margin = new Padding(8, 0, 3, 0);
         this.labelAlpha.Name = "labelAlpha";
-        this.labelAlpha.Size = new System.Drawing.Size(38, 15);
+        this.labelAlpha.Size = new Size(38, 15);
         this.labelAlpha.TabIndex = 12;
         this.labelAlpha.Text = "Alpha";
-        this.labelAlpha.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+        this.labelAlpha.TextAlign = ContentAlignment.MiddleRight;
         // 
         // TableTop
         // 
         this.TableTop.ColumnCount = 6;
-        this.TableTop.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-        this.TableTop.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.TableTop.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.TableTop.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.TableTop.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.TableTop.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-        this.TableTop.Controls.Add(this.tableLayoutPanel3, 4, 0);
+        this.TableTop.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+        this.TableTop.ColumnStyles.Add(new ColumnStyle());
+        this.TableTop.ColumnStyles.Add(new ColumnStyle());
+        this.TableTop.ColumnStyles.Add(new ColumnStyle());
+        this.TableTop.ColumnStyles.Add(new ColumnStyle());
+        this.TableTop.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
         this.TableTop.Controls.Add(this.colorPanel, 1, 0);
         this.TableTop.Controls.Add(this.colorSlider, 2, 0);
         this.TableTop.Controls.Add(this.alphaSlider, 3, 0);
-        this.TableTop.Dock = System.Windows.Forms.DockStyle.Top;
-        this.TableTop.Location = new System.Drawing.Point(0, 0);
+        this.TableTop.Controls.Add(this.tableLayoutPanel3, 4, 0);
+        this.TableTop.Dock = DockStyle.Top;
+        this.TableTop.Location = new Point(0, 0);
         this.TableTop.Name = "TableTop";
         this.TableTop.RowCount = 1;
-        this.TableTop.RowStyles.Add(new System.Windows.Forms.RowStyle());
-        this.TableTop.Size = new System.Drawing.Size(400, 187);
+        this.TableTop.RowStyles.Add(new RowStyle());
+        this.TableTop.Size = new Size(400, 187);
         this.TableTop.TabIndex = 1;
         // 
         // tableLayoutPanel3
         // 
-        this.tableLayoutPanel3.Anchor = System.Windows.Forms.AnchorStyles.Left;
-        this.tableLayoutPanel3.AutoSize = true;
-        this.tableLayoutPanel3.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+        this.tableLayoutPanel3.Anchor = AnchorStyles.Left;
+        this.tableLayoutPanel3.AutoSizeMode = AutoSizeMode.GrowAndShrink;
         this.tableLayoutPanel3.ColumnCount = 1;
-        this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+        this.tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
         this.tableLayoutPanel3.Controls.Add(this.colorShowBox, 0, 1);
         this.tableLayoutPanel3.Controls.Add(this.label2, 0, 2);
         this.tableLayoutPanel3.Controls.Add(this.label1, 0, 0);
-        this.tableLayoutPanel3.Location = new System.Drawing.Point(308, 40);
-        this.tableLayoutPanel3.MinimumSize = new System.Drawing.Size(64, 102);
+        this.tableLayoutPanel3.Location = new Point(308, 40);
+        this.tableLayoutPanel3.MaximumSize = new Size(64, 106);
+        this.tableLayoutPanel3.MinimumSize = new Size(64, 102);
         this.tableLayoutPanel3.Name = "tableLayoutPanel3";
         this.tableLayoutPanel3.RowCount = 3;
-        this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-        this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 64F));
-        this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-        this.tableLayoutPanel3.Size = new System.Drawing.Size(64, 106);
+        this.tableLayoutPanel3.RowStyles.Add(new RowStyle());
+        this.tableLayoutPanel3.RowStyles.Add(new RowStyle(SizeType.Absolute, 64F));
+        this.tableLayoutPanel3.RowStyles.Add(new RowStyle());
+        this.tableLayoutPanel3.Size = new Size(64, 106);
         this.tableLayoutPanel3.TabIndex = 9;
         // 
         // colorShowBox
         // 
-        this.colorShowBox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-        this.colorShowBox.AutoSize = true;
-        this.colorShowBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.colorShowBox.Color = System.Drawing.Color.DarkRed;
-        this.colorShowBox.Location = new System.Drawing.Point(3, 24);
-        this.colorShowBox.LowerColor = System.Drawing.Color.Maroon;
+        this.colorShowBox.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+        this.colorShowBox.BorderStyle = BorderStyle.FixedSingle;
+        this.colorShowBox.Color = Color.DarkRed;
+        this.colorShowBox.Location = new Point(3, 24);
+        this.colorShowBox.LowerColor = Color.Maroon;
+        this.colorShowBox.MaximumSize = new Size(58, 58);
+        this.colorShowBox.MinimumSize = new Size(58, 58);
         this.colorShowBox.Name = "colorShowBox";
-        this.colorShowBox.Padding = new System.Windows.Forms.Padding(0, 3, 0, 3);
-        this.colorShowBox.Size = new System.Drawing.Size(58, 58);
+        this.colorShowBox.Padding = new Padding(0, 3, 0, 3);
+        this.colorShowBox.Size = new Size(58, 58);
         this.colorShowBox.TabIndex = 2;
-        this.colorShowBox.UpperColor = System.Drawing.Color.DarkRed;
-        this.colorShowBox.UpperClick += new System.EventHandler(this.ColorShowBox_UpperClick);
+        this.colorShowBox.UpperColor = Color.DarkRed;
+        this.colorShowBox.UpperClick += this.ColorShowBox_UpperClick;
         // 
         // label2
         // 
-        this.label2.Anchor = System.Windows.Forms.AnchorStyles.None;
+        this.label2.Anchor = AnchorStyles.None;
         this.label2.AutoSize = true;
-        this.label2.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.label2.Location = new System.Drawing.Point(8, 88);
-        this.label2.Margin = new System.Windows.Forms.Padding(3);
+        this.label2.ImeMode = ImeMode.NoControl;
+        this.label2.Location = new Point(8, 88);
+        this.label2.Margin = new Padding(3);
         this.label2.Name = "label2";
-        this.label2.Size = new System.Drawing.Size(47, 15);
+        this.label2.Size = new Size(47, 15);
         this.label2.TabIndex = 4;
         this.label2.Text = "Current";
-        this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+        this.label2.TextAlign = ContentAlignment.MiddleCenter;
         // 
         // label1
         // 
-        this.label1.Anchor = System.Windows.Forms.AnchorStyles.None;
+        this.label1.Anchor = AnchorStyles.None;
         this.label1.AutoSize = true;
-        this.label1.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-        this.label1.Location = new System.Drawing.Point(19, 3);
-        this.label1.Margin = new System.Windows.Forms.Padding(3);
+        this.label1.ImeMode = ImeMode.NoControl;
+        this.label1.Location = new Point(19, 3);
+        this.label1.Margin = new Padding(3);
         this.label1.Name = "label1";
-        this.label1.Size = new System.Drawing.Size(26, 15);
+        this.label1.Size = new Size(26, 15);
         this.label1.TabIndex = 3;
         this.label1.Text = "Old";
-        this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+        this.label1.TextAlign = ContentAlignment.MiddleCenter;
         // 
         // colorPanel
         // 
-        this.colorPanel.Anchor = System.Windows.Forms.AnchorStyles.None;
-        this.colorPanel.BottomLeftColor = System.Drawing.Color.Black;
-        this.colorPanel.BottomRightColor = System.Drawing.Color.Black;
-        this.colorPanel.Location = new System.Drawing.Point(28, 6);
+        this.colorPanel.Anchor = AnchorStyles.None;
+        this.colorPanel.BottomLeftColor = Color.Black;
+        this.colorPanel.BottomRightColor = Color.Black;
+        this.colorPanel.Location = new Point(28, 6);
+        this.colorPanel.MaximumSize = new Size(198, 175);
+        this.colorPanel.MinimumSize = new Size(198, 175);
         this.colorPanel.Name = "colorPanel";
-        this.colorPanel.Size = new System.Drawing.Size(198, 175);
+        this.colorPanel.Size = new Size(198, 175);
         this.colorPanel.TabIndex = 0;
-        this.colorPanel.TopLeftColor = System.Drawing.Color.White;
-        this.colorPanel.TopRightColor = System.Drawing.Color.Red;
-        this.colorPanel.PercentualValueChanged += new System.EventHandler(this.ColorPanel_PercentualValueChanged);
+        this.colorPanel.TopLeftColor = Color.White;
+        this.colorPanel.TopRightColor = Color.Red;
+        this.colorPanel.ValuePercentual = (PointF)resources.GetObject("colorPanel.ValuePercentual");
+        this.colorPanel.PercentualValueChanged += this.ColorPanel_PercentualValueChanged;
         // 
         // colorSlider
         // 
-        this.colorSlider.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom;
-        this.colorSlider.Location = new System.Drawing.Point(232, 3);
+        this.colorSlider.Anchor = AnchorStyles.Top | AnchorStyles.Bottom;
+        this.colorSlider.Location = new Point(232, 3);
+        this.colorSlider.MaximumSize = new Size(32, 181);
+        this.colorSlider.MinimumSize = new Size(32, 181);
         this.colorSlider.Name = "colorSlider";
         this.colorSlider.ShowInnerPicker = false;
-        this.colorSlider.Size = new System.Drawing.Size(32, 181);
+        this.colorSlider.Size = new Size(32, 181);
         this.colorSlider.TabIndex = 1;
-        this.colorSlider.PercentualValueChanged += new System.EventHandler(this.ColorSlider_PercentualValueChanged);
+        this.colorSlider.PercentualValueChanged += this.ColorSlider_PercentualValueChanged;
         // 
         // alphaSlider
         // 
-        this.alphaSlider.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom;
-        this.alphaSlider.Location = new System.Drawing.Point(270, 3);
-        this.alphaSlider.Maximum = System.Drawing.Color.White;
-        this.alphaSlider.Minimum = System.Drawing.Color.Transparent;
+        this.alphaSlider.Anchor = AnchorStyles.Top | AnchorStyles.Bottom;
+        this.alphaSlider.Location = new Point(270, 3);
+        this.alphaSlider.Maximum = Color.White;
+        this.alphaSlider.MaximumSize = new Size(32, 181);
+        this.alphaSlider.Minimum = Color.Transparent;
+        this.alphaSlider.MinimumSize = new Size(32, 181);
         this.alphaSlider.Name = "alphaSlider";
         this.alphaSlider.ShowInnerPicker = false;
-        this.alphaSlider.Size = new System.Drawing.Size(32, 181);
+        this.alphaSlider.Size = new Size(32, 181);
         this.alphaSlider.TabIndex = 2;
-        this.alphaSlider.PercentualValueChanged += new System.EventHandler(this.AlphaSlider_PercentualValueChanged);
+        this.alphaSlider.PercentualValueChanged += this.AlphaSlider_PercentualValueChanged;
         // 
         // TableBottom
         // 
         this.TableBottom.ColumnCount = 8;
-        this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-        this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.TableBottom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+        this.TableBottom.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+        this.TableBottom.ColumnStyles.Add(new ColumnStyle());
+        this.TableBottom.ColumnStyles.Add(new ColumnStyle());
+        this.TableBottom.ColumnStyles.Add(new ColumnStyle());
+        this.TableBottom.ColumnStyles.Add(new ColumnStyle());
+        this.TableBottom.ColumnStyles.Add(new ColumnStyle());
+        this.TableBottom.ColumnStyles.Add(new ColumnStyle());
+        this.TableBottom.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
         this.TableBottom.Controls.Add(this.textBoxHex, 6, 2);
         this.TableBottom.Controls.Add(this.labelHex, 5, 2);
         this.TableBottom.Controls.Add(this.numAlpha, 6, 0);
@@ -388,47 +396,49 @@ partial class ColorPickerPanel
         this.TableBottom.Controls.Add(this.radioSaturation, 1, 1);
         this.TableBottom.Controls.Add(this.radioHue, 1, 0);
         this.TableBottom.Controls.Add(this.numHue, 2, 0);
-        this.TableBottom.Dock = System.Windows.Forms.DockStyle.Fill;
-        this.TableBottom.Location = new System.Drawing.Point(0, 187);
+        this.TableBottom.Dock = DockStyle.Fill;
+        this.TableBottom.Location = new Point(0, 187);
         this.TableBottom.Name = "TableBottom";
-        this.TableBottom.Padding = new System.Windows.Forms.Padding(3, 0, 0, 0);
+        this.TableBottom.Padding = new Padding(3, 0, 0, 0);
         this.TableBottom.RowCount = 4;
-        this.TableBottom.RowStyles.Add(new System.Windows.Forms.RowStyle());
-        this.TableBottom.RowStyles.Add(new System.Windows.Forms.RowStyle());
-        this.TableBottom.RowStyles.Add(new System.Windows.Forms.RowStyle());
-        this.TableBottom.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-        this.TableBottom.Size = new System.Drawing.Size(400, 88);
+        this.TableBottom.RowStyles.Add(new RowStyle());
+        this.TableBottom.RowStyles.Add(new RowStyle());
+        this.TableBottom.RowStyles.Add(new RowStyle());
+        this.TableBottom.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        this.TableBottom.Size = new Size(400, 88);
         this.TableBottom.TabIndex = 0;
         // 
         // textBoxHex
         // 
-        this.textBoxHex.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-        this.textBoxHex.Location = new System.Drawing.Point(308, 61);
+        this.textBoxHex.Anchor = AnchorStyles.None;
+        this.textBoxHex.Location = new Point(308, 61);
         this.textBoxHex.Name = "textBoxHex";
-        this.textBoxHex.Size = new System.Drawing.Size(65, 23);
+        this.textBoxHex.Size = new Size(65, 23);
         this.textBoxHex.TabIndex = 15;
-        this.textBoxHex.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-        this.textBoxHex.TextChanged += new System.EventHandler(this.TextBoxHex_TextChanged);
+        this.textBoxHex.TextAlign = HorizontalAlignment.Right;
+        this.textBoxHex.TextChanged += this.TextBoxHex_TextChanged;
         // 
         // numAlpha
         // 
-        this.numAlpha.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-        this.numAlpha.Location = new System.Drawing.Point(308, 3);
+        this.numAlpha.Anchor = AnchorStyles.None;
+        this.numAlpha.Location = new Point(308, 3);
         this.numAlpha.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
         this.numAlpha.Name = "numAlpha";
-        this.numAlpha.Size = new System.Drawing.Size(65, 23);
+        this.numAlpha.Size = new Size(65, 23);
         this.numAlpha.TabIndex = 13;
-        this.numAlpha.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-        this.numAlpha.ValueChanged += new System.EventHandler(this.NumAlpha_ValueChanged);
+        this.numAlpha.TextAlign = HorizontalAlignment.Right;
+        this.numAlpha.ValueChanged += this.NumAlpha_ValueChanged;
         // 
         // ColorPickerPanel
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+        this.AutoScaleDimensions = new SizeF(7F, 15F);
+        this.AutoScaleMode = AutoScaleMode.Font;
         this.Controls.Add(this.TableBottom);
         this.Controls.Add(this.TableTop);
+        this.MaximumSize = new Size(400, 275);
+        this.MinimumSize = new Size(400, 275);
         this.Name = "ColorPickerPanel";
-        this.Size = new System.Drawing.Size(400, 275);
+        this.Size = new Size(400, 275);
         ((System.ComponentModel.ISupportInitialize)this.numHue).EndInit();
         ((System.ComponentModel.ISupportInitialize)this.numSaturation).EndInit();
         ((System.ComponentModel.ISupportInitialize)this.numValue).EndInit();
@@ -436,7 +446,6 @@ partial class ColorPickerPanel
         ((System.ComponentModel.ISupportInitialize)this.numGreen).EndInit();
         ((System.ComponentModel.ISupportInitialize)this.numBlue).EndInit();
         this.TableTop.ResumeLayout(false);
-        this.TableTop.PerformLayout();
         this.tableLayoutPanel3.ResumeLayout(false);
         this.tableLayoutPanel3.PerformLayout();
         this.TableBottom.ResumeLayout(false);

--- a/Dependencies/WinFormsColor/Source/WinFormsColor/ColorPickerPanel.resx
+++ b/Dependencies/WinFormsColor/Source/WinFormsColor/ColorPickerPanel.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -117,4 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="colorPanel.ValuePercentual" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFFTeXN0ZW0uRHJhd2luZywgVmVyc2lvbj00LjAuMC4wLCBDdWx0
+        dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWIwM2Y1ZjdmMTFkNTBhM2EFAQAAABVTeXN0ZW0uRHJh
+        d2luZy5Qb2ludEYCAAAAAXgBeQAACwsCAAAAAAAAPwAAAD8L
+</value>
+  </data>
 </root>

--- a/Dependencies/WinFormsColor/Source/WinFormsColor/ColorSlider.cs
+++ b/Dependencies/WinFormsColor/Source/WinFormsColor/ColorSlider.cs
@@ -303,6 +303,12 @@ public class ColorSlider : UserControl
         designSerializeColor = false;
     }
     private bool ShouldSerializeMinimum() => designSerializeColor;
+
+    private void InitializeComponent()
+    {
+
+    }
+
     private bool ShouldSerializeMaximum() => designSerializeColor;
 }
 

--- a/Dependencies/WinFormsColor/Source/WinFormsColor/ColorSlider.resx
+++ b/Dependencies/WinFormsColor/Source/WinFormsColor/ColorSlider.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/Examples/Gorgon.Core/Example002/formMain.Designer.cs
+++ b/Examples/Gorgon.Core/Example002/formMain.Designer.cs
@@ -59,7 +59,7 @@ namespace Gorgon.Examples;
         // 
         // formMain
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.ClientSize = new System.Drawing.Size(733, 327);
         this.Controls.Add(this.panelGraphics);

--- a/Examples/Gorgon.Core/Example003/formMain.Designer.cs
+++ b/Examples/Gorgon.Core/Example003/formMain.Designer.cs
@@ -84,7 +84,7 @@ partial class FormMain
         // 
         // formMain
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.ClientSize = new System.Drawing.Size(539, 253);
         this.Controls.Add(this.panelGraphics);

--- a/Examples/Gorgon.Core/Example003/formSplash.Designer.cs
+++ b/Examples/Gorgon.Core/Example003/formSplash.Designer.cs
@@ -58,8 +58,8 @@ partial class FormSplash
         // 
         // FormSplash
         // 
-        AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        AutoScaleMode = AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
         BackColor = System.Drawing.Color.White;
         BackgroundImageLayout = ImageLayout.Center;
         ClientSize = new System.Drawing.Size(622, 150);

--- a/Examples/Gorgon.FileSystem/BZipFileSystemOPower/Form.Designer.cs
+++ b/Examples/Gorgon.FileSystem/BZipFileSystemOPower/Form.Designer.cs
@@ -33,7 +33,7 @@ namespace Gorgon.Examples;
         // 
         // MainForm
         // 
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.ClientSize = new System.Drawing.Size(1264, 761);
         
         this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));

--- a/Examples/Gorgon.FileSystem/FolderFileSystemOPower/Form.Designer.cs
+++ b/Examples/Gorgon.FileSystem/FolderFileSystemOPower/Form.Designer.cs
@@ -33,7 +33,7 @@ namespace Gorgon.Examples;
         // 
         // MainForm
         // 
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.ClientSize = new System.Drawing.Size(1264, 761);
         
         this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));

--- a/Examples/Gorgon.Renderers.2D/GiveMeSomeControl/Form.Designer.cs
+++ b/Examples/Gorgon.Renderers.2D/GiveMeSomeControl/Form.Designer.cs
@@ -106,8 +106,8 @@ partial class Form
         // 
         // Form
         // 
-        AutoScaleDimensions = new SizeF(96F, 96F);
-        AutoScaleMode = AutoScaleMode.Dpi;
+        AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
         BackColor = Color.White;
         ClientSize = new Size(1106, 571);
         Controls.Add(SplitViews);

--- a/Gorgon/Gorgon.Windows/UI/_Controls/GorgonAlignmentPicker.Designer.cs
+++ b/Gorgon/Gorgon.Windows/UI/_Controls/GorgonAlignmentPicker.Designer.cs
@@ -230,7 +230,7 @@ partial class GorgonAlignmentPicker
         // 
         // GorgonAlignmentPicker
         // 
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.Controls.Add(this.panelAnchor);
         this.Name = "GorgonAlignmentPicker";
         this.Size = new System.Drawing.Size(105, 105);

--- a/Gorgon/Gorgon.Windows/UI/_Controls/GorgonFolderBrowser.Designer.cs
+++ b/Gorgon/Gorgon.Windows/UI/_Controls/GorgonFolderBrowser.Designer.cs
@@ -328,8 +328,8 @@ partial class GorgonFolderBrowser
         // 
         // GorgonFolderBrowser
         // 
-        AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        AutoScaleDimensions = new SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
         BackColor = System.Drawing.Color.FromArgb(204, 204, 204);
         Controls.Add(PanelDirectories);
         Controls.Add(PanelDirectoryName);

--- a/Gorgon/Gorgon.Windows/UI/_Controls/GorgonProgressPanel.Designer.cs
+++ b/Gorgon/Gorgon.Windows/UI/_Controls/GorgonProgressPanel.Designer.cs
@@ -116,8 +116,8 @@ partial class GorgonProgressPanel
         // 
         // GorgonProgressPanel
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.BackColor = System.Drawing.Color.White;
         this.Controls.Add(this.PanelLayout);
         

--- a/Gorgon/Gorgon.Windows/UI/_Controls/GorgonSearchBox.Designer.cs
+++ b/Gorgon/Gorgon.Windows/UI/_Controls/GorgonSearchBox.Designer.cs
@@ -97,8 +97,8 @@ partial class GorgonSearchBox
         // 
         // GorgonSearchBox
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.BackColor = System.Drawing.Color.White;
         this.Controls.Add(this.tableLayoutPanel1);
         

--- a/Gorgon/Gorgon.Windows/UI/_Controls/GorgonWaitMessagePanel.Designer.cs
+++ b/Gorgon/Gorgon.Windows/UI/_Controls/GorgonWaitMessagePanel.Designer.cs
@@ -68,7 +68,7 @@ partial class GorgonWaitMessagePanel
         // GorgonWaitMessagePanel
         // 
         resources.ApplyResources(this, "$this");
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.BackColor = System.Drawing.Color.White;
         this.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
         this.Controls.Add(this.PanelWait);

--- a/Gorgon/Gorgon.Windows/UI/_Forms/_Internal/BaseDialog.designer.cs
+++ b/Gorgon/Gorgon.Windows/UI/_Forms/_Internal/BaseDialog.designer.cs
@@ -89,8 +89,8 @@ partial class BaseDialog
         // BaseDialog
         // 
         AcceptButton = buttonOK;
-        AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        AutoScaleMode = AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
         ClientSize = new System.Drawing.Size(304, 134);
         Controls.Add(pictureDialog);
         Controls.Add(buttonOK);

--- a/Gorgon/Gorgon.Windows/UI/_Forms/_Internal/ConfirmationDialog.designer.cs
+++ b/Gorgon/Gorgon.Windows/UI/_Forms/_Internal/ConfirmationDialog.designer.cs
@@ -106,8 +106,8 @@ namespace Gorgon.UI;
         // 
         // ConfirmationDialog
         // 
-        AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        AutoScaleMode = AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
         ClientSize = new System.Drawing.Size(303, 130);
         Controls.Add(buttonNo);
         Controls.Add(buttonCancel);

--- a/Gorgon/Gorgon.Windows/UI/_Forms/_Internal/ErrorDialog.designer.cs
+++ b/Gorgon/Gorgon.Windows/UI/_Forms/_Internal/ErrorDialog.designer.cs
@@ -113,8 +113,8 @@ namespace Gorgon.UI;
         // 
         // ErrorDialog
         // 
-        AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        AutoScaleMode = AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
         ClientSize = new System.Drawing.Size(303, 130);
         Controls.Add(checkDetail);
         Controls.Add(errorDetails);

--- a/Gorgon/Gorgon.Windows/UI/_Forms/_Internal/FormOverlay.Designer.cs
+++ b/Gorgon/Gorgon.Windows/UI/_Forms/_Internal/FormOverlay.Designer.cs
@@ -34,8 +34,8 @@ partial class FormOverlay
         // 
         // FormOverlay
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.BackColor = System.Drawing.Color.Black;
         this.ClientSize = new System.Drawing.Size(904, 670);
         this.ControlBox = false;

--- a/Gorgon/Gorgon.Windows/UI/_Forms/_Internal/FormProgress.Designer.cs
+++ b/Gorgon/Gorgon.Windows/UI/_Forms/_Internal/FormProgress.Designer.cs
@@ -55,8 +55,8 @@ partial class FormProgress
         // 
         // FormProgress
         // 
-        AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         AutoSize = true;
         AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
         BackColor = System.Drawing.Color.Black;

--- a/Gorgon/Gorgon.Windows/UI/_Forms/_Internal/WarningDialog.designer.cs
+++ b/Gorgon/Gorgon.Windows/UI/_Forms/_Internal/WarningDialog.designer.cs
@@ -113,8 +113,8 @@ namespace Gorgon.UI;
         // 
         // WarningDialog
         // 
-        AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        AutoScaleMode = AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
         ClientSize = new System.Drawing.Size(303, 130);
         Controls.Add(checkDetail);
         Controls.Add(textWarningDetails);

--- a/PlugIns/Gorgon.Editor.FontEditor/_Internal/Forms/FormCharacterPicker.Designer.cs
+++ b/PlugIns/Gorgon.Editor.FontEditor/_Internal/Forms/FormCharacterPicker.Designer.cs
@@ -49,8 +49,8 @@
         // 
         // FormCharacterPicker
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(28)))), ((int)(((byte)(28)))), ((int)(((byte)(28)))));
         this.ClientSize = new System.Drawing.Size(687, 444);
         this.Controls.Add(this.CharPicker);

--- a/PlugIns/Gorgon.Editor.FontEditor/_Internal/Forms/FormNewFont.Designer.cs
+++ b/PlugIns/Gorgon.Editor.FontEditor/_Internal/Forms/FormNewFont.Designer.cs
@@ -512,8 +512,8 @@
         // FormNewFont
         // 
         this.AcceptButton = this.ButtonOK;
-        this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(28)))), ((int)(((byte)(28)))), ((int)(((byte)(28)))));
         this.CancelButton = this.ButtonCancel;
         this.ClientSize = new System.Drawing.Size(516, 346);

--- a/PlugIns/Gorgon.Editor.FontEditor/_Internal/Views/FontGradientBrushView.Designer.cs
+++ b/PlugIns/Gorgon.Editor.FontEditor/_Internal/Views/FontGradientBrushView.Designer.cs
@@ -462,8 +462,8 @@ namespace Gorgon.Editor.FontEditor;
         // 
         // FontGradientBrushView
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(28)))), ((int)(((byte)(28)))), ((int)(((byte)(28)))));
         this.Name = "FontGradientBrushView";
         this.Size = new System.Drawing.Size(364, 682);

--- a/PlugIns/Gorgon.Editor.FontEditor/_Internal/Views/FontPatternBrushView.Designer.cs
+++ b/PlugIns/Gorgon.Editor.FontEditor/_Internal/Views/FontPatternBrushView.Designer.cs
@@ -201,8 +201,8 @@ namespace Gorgon.Editor.FontEditor;
         // 
         // FontPatternBrushView
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(28)))), ((int)(((byte)(28)))), ((int)(((byte)(28)))));
         this.Name = "FontPatternBrushView";
         this.Size = new System.Drawing.Size(364, 774);

--- a/PlugIns/Gorgon.Editor.FontEditor/_Internal/Views/FontTextureBrushView.designer.cs
+++ b/PlugIns/Gorgon.Editor.FontEditor/_Internal/Views/FontTextureBrushView.designer.cs
@@ -252,8 +252,8 @@ partial class FontTextureBrushView
         // 
         // FontTextureBrushView
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.Name = "FontTextureBrushView";
         this.Size = new System.Drawing.Size(364, 680);
         this.Text = "Font Brush - Texture";

--- a/PlugIns/Gorgon.Editor.SpriteEditor/_Internal/Forms/FormManualRectangleEdit.Designer.cs
+++ b/PlugIns/Gorgon.Editor.SpriteEditor/_Internal/Forms/FormManualRectangleEdit.Designer.cs
@@ -236,7 +236,7 @@ partial class FormManualRectangleEdit
         // 
         // FormManualRectangleEdit
         // 
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.AutoSize = true;
         this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
         this.ClientSize = new System.Drawing.Size(358, 243);

--- a/PlugIns/Gorgon.Editor.SpriteEditor/_Internal/Views/SpriteColor.Designer.cs
+++ b/PlugIns/Gorgon.Editor.SpriteEditor/_Internal/Views/SpriteColor.Designer.cs
@@ -35,42 +35,41 @@ partial class SpriteColor
     /// </summary>
     private void InitializeComponent()
     {
-            this.Picker = new Gorgon.Editor.UI.Controls.ColorPicker();
-            this.PanelBody.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // PanelBody
-            // 
-            this.PanelBody.Controls.Add(this.Picker);
-            this.PanelBody.Size = new System.Drawing.Size(364, 411);
-            // 
-            // Picker
-            // 
-            this.Picker.AutoSize = true;
-            this.Picker.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Picker.Font = new System.Drawing.Font("Segoe UI", 9F);
-            this.Picker.Location = new System.Drawing.Point(0, 0);
-            this.Picker.Name = "Picker";
-            this.Picker.Size = new System.Drawing.Size(364, 411);
-            this.Picker.TabIndex = 0;
-            this.Picker.ColorChanged += new System.EventHandler<Gorgon.Editor.UI.Controls.ColorChangedEventArgs>(this.Picker_ColorChanged);
-            // 
-            // SpriteColor
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ForeColor = System.Drawing.Color.White;
-            this.Name = "SpriteColor";
-            this.Size = new System.Drawing.Size(364, 468);
-            this.Text = "Sprite Color";
-            this.PanelBody.ResumeLayout(false);
-            this.PanelBody.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+        Picker = new UI.Controls.ColorPicker();
+        PanelBody.SuspendLayout();
+        SuspendLayout();
+        // 
+        // PanelBody
+        // 
+        PanelBody.Controls.Add(Picker);
+        PanelBody.Size = new Size(360, 288);
+        // 
+        // Picker
+        // 
+        Picker.AutoSize = true;
+        Picker.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        Picker.Dock = DockStyle.Fill;
+        Picker.Font = new Font("Segoe UI", 9F);
+        Picker.Location = new Point(0, 0);
+        Picker.Name = "Picker";
+        Picker.Size = new Size(360, 288);
+        Picker.TabIndex = 0;
+        Picker.ColorChanged += Picker_ColorChanged;
+        // 
+        // SpriteColor
+        // 
+        AutoScaleDimensions = new SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
+        AutoSize = true;
+        AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        Name = "SpriteColor";
+        Size = new Size(360, 345);
+        Text = "Sprite Color";
+        PanelBody.ResumeLayout(false);
+        PanelBody.PerformLayout();
+        ResumeLayout(false);
+        PerformLayout();
     }
-
-
 
     private UI.Controls.ColorPicker Picker;
 }

--- a/PlugIns/Gorgon.Editor.SpriteEditor/_Internal/Views/SpriteColor.resx
+++ b/PlugIns/Gorgon.Editor.SpriteEditor/_Internal/Views/SpriteColor.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/PlugIns/Gorgon.Editor.SpriteEditor/_Internal/Views/SpriteEditorView.Designer.cs
+++ b/PlugIns/Gorgon.Editor.SpriteEditor/_Internal/Views/SpriteEditorView.Designer.cs
@@ -91,225 +91,235 @@ partial class SpriteEditorView
     /// </summary>
     private void InitializeComponent()
     {
-        this.SpriteWrapping = new Gorgon.Editor.SpriteEditor.SpriteWrap();
-        this.SpritePickMaskColor = new Gorgon.Editor.SpriteEditor.SpritePickMaskColor();
-        this.SpriteColorSelector = new Gorgon.Editor.SpriteEditor.SpriteColor();
-        this.SpriteAnchorSelector = new Gorgon.Editor.SpriteEditor.SpriteAnchor();
-        this.PanelImageViewControls = new System.Windows.Forms.TableLayoutPanel();
-        this.LabelSpriteInfo = new System.Windows.Forms.Label();
-        this.LabelArrayIndexDetails = new System.Windows.Forms.Label();
-        this.ButtonPrevArrayIndex = new System.Windows.Forms.Button();
-        this.ButtonNextArrayIndex = new System.Windows.Forms.Button();
-        this.LabelArrayIndex = new System.Windows.Forms.Label();
-        this.StatusPanel.SuspendLayout();
-        this.HostPanel.SuspendLayout();
-        this.HostPanelControls.SuspendLayout();
-        this.PanelImageViewControls.SuspendLayout();
-        this.SuspendLayout();
+        SpriteWrapping = new SpriteWrap();
+        SpritePickMaskColor = new SpritePickMaskColor();
+        SpriteColorSelector = new SpriteColor();
+        SpriteAnchorSelector = new SpriteAnchor();
+        PanelImageViewControls = new TableLayoutPanel();
+        LabelSpriteInfo = new Label();
+        LabelArrayIndexDetails = new Label();
+        ButtonPrevArrayIndex = new Button();
+        ButtonNextArrayIndex = new Button();
+        LabelArrayIndex = new Label();
+        flowLayoutPanel1 = new FlowLayoutPanel();
+        StatusPanel.SuspendLayout();
+        HostPanel.SuspendLayout();
+        HostPanelControls.SuspendLayout();
+        PanelImageViewControls.SuspendLayout();
+        flowLayoutPanel1.SuspendLayout();
+        SuspendLayout();
         // 
         // StatusPanel
         // 
-        this.StatusPanel.Controls.Add(this.PanelImageViewControls);
-        this.StatusPanel.Location = new System.Drawing.Point(0, 760);
-        this.StatusPanel.Size = new System.Drawing.Size(844, 24);
+        StatusPanel.Controls.Add(PanelImageViewControls);
+        StatusPanel.Location = new Point(0, 760);
+        StatusPanel.Size = new Size(712, 24);
         // 
         // PresentationPanel
         // 
-        this.PresentationPanel.Location = new System.Drawing.Point(0, 21);
-        this.PresentationPanel.Size = new System.Drawing.Size(844, 739);
+        PresentationPanel.Location = new Point(0, 21);
+        PresentationPanel.Size = new Size(712, 739);
         // 
         // HostPanel
         // 
-        this.HostPanel.Location = new System.Drawing.Point(844, 21);
-        this.HostPanel.Size = new System.Drawing.Size(393, 763);
+        HostPanel.Location = new Point(712, 21);
+        HostPanel.Size = new Size(396, 763);
         // 
         // HostPanelControls
         // 
-        this.HostPanelControls.Controls.Add(this.SpriteAnchorSelector);
-        this.HostPanelControls.Controls.Add(this.SpriteColorSelector);
-        this.HostPanelControls.Controls.Add(this.SpriteWrapping);
-        this.HostPanelControls.Controls.Add(this.SpritePickMaskColor);
-        this.HostPanelControls.Size = new System.Drawing.Size(392, 762);
+        HostPanelControls.Controls.Add(flowLayoutPanel1);
+        HostPanelControls.Size = new Size(395, 762);
         // 
         // SpriteWrapping
         // 
-        this.SpriteWrapping.AutoSize = true;
-        this.SpriteWrapping.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(28)))), ((int)(((byte)(28)))), ((int)(((byte)(28)))));
-        this.SpriteWrapping.Font = new System.Drawing.Font("Segoe UI", 9F);
-        this.SpriteWrapping.ForeColor = System.Drawing.Color.White;
-        this.SpriteWrapping.Location = new System.Drawing.Point(0, 64);
-        this.SpriteWrapping.Name = "SpriteWrapping";
-        this.SpriteWrapping.Size = new System.Drawing.Size(389, 365);
-        this.SpriteWrapping.TabIndex = 3;
-        this.SpriteWrapping.Text = "Sprite Texture Wrapping";
-        this.SpriteWrapping.Visible = false;
+        SpriteWrapping.AutoSize = true;
+        SpriteWrapping.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        SpriteWrapping.BackColor = Color.FromArgb(28, 28, 28);
+        SpriteWrapping.Font = new Font("Segoe UI", 9F);
+        SpriteWrapping.ForeColor = Color.White;
+        SpriteWrapping.Location = new Point(3, 929);
+        SpriteWrapping.Name = "SpriteWrapping";
+        SpriteWrapping.Size = new Size(282, 229);
+        SpriteWrapping.TabIndex = 3;
+        SpriteWrapping.Text = "Sprite Texture Wrapping";
+        SpriteWrapping.Visible = false;
         // 
         // SpritePickMaskColor
         // 
-        this.SpritePickMaskColor.AutoSize = true;
-        this.SpritePickMaskColor.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(28)))), ((int)(((byte)(28)))), ((int)(((byte)(28)))));
-        this.SpritePickMaskColor.Font = new System.Drawing.Font("Segoe UI", 9F);
-        this.SpritePickMaskColor.ForeColor = System.Drawing.Color.White;
-        this.SpritePickMaskColor.IsModal = false;
-        this.SpritePickMaskColor.Location = new System.Drawing.Point(0, 128);
-        this.SpritePickMaskColor.Name = "SpritePickMaskColor";
-        this.SpritePickMaskColor.Size = new System.Drawing.Size(389, 406);
-        this.SpritePickMaskColor.TabIndex = 2;
-        this.SpritePickMaskColor.Text = "Sprite Picker Mask Color";
-        this.SpritePickMaskColor.Visible = false;
+        SpritePickMaskColor.AutoSize = true;
+        SpritePickMaskColor.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        SpritePickMaskColor.BackColor = Color.FromArgb(28, 28, 28);
+        SpritePickMaskColor.Font = new Font("Segoe UI", 9F);
+        SpritePickMaskColor.ForeColor = Color.White;
+        SpritePickMaskColor.IsModal = false;
+        SpritePickMaskColor.Location = new Point(3, 264);
+        SpritePickMaskColor.Name = "SpritePickMaskColor";
+        SpritePickMaskColor.Size = new Size(389, 308);
+        SpritePickMaskColor.TabIndex = 2;
+        SpritePickMaskColor.Text = "Sprite Picker Mask Color";
+        SpritePickMaskColor.Visible = false;
         // 
         // SpriteColorSelector
         // 
-        this.SpriteColorSelector.AutoSize = true;
-        this.SpriteColorSelector.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(28)))), ((int)(((byte)(28)))), ((int)(((byte)(28)))));
-        this.SpriteColorSelector.Font = new System.Drawing.Font("Segoe UI", 9F);
-        this.SpriteColorSelector.ForeColor = System.Drawing.Color.White;
-        this.SpriteColorSelector.Location = new System.Drawing.Point(0, 32);
-        this.SpriteColorSelector.Name = "SpriteColorSelector";
-        this.SpriteColorSelector.Size = new System.Drawing.Size(389, 406);
-        this.SpriteColorSelector.TabIndex = 0;
-        this.SpriteColorSelector.Text = "Sprite Color";
-        this.SpriteColorSelector.Visible = false;
+        SpriteColorSelector.AutoSize = true;
+        SpriteColorSelector.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        SpriteColorSelector.BackColor = Color.FromArgb(28, 28, 28);
+        SpriteColorSelector.Font = new Font("Segoe UI", 9F);
+        SpriteColorSelector.ForeColor = Color.White;
+        SpriteColorSelector.Location = new Point(3, 578);
+        SpriteColorSelector.Name = "SpriteColorSelector";
+        SpriteColorSelector.Size = new Size(360, 345);
+        SpriteColorSelector.TabIndex = 0;
+        SpriteColorSelector.Text = "Sprite Color";
+        SpriteColorSelector.Visible = false;
         // 
         // SpriteAnchorSelector
         // 
-        this.SpriteAnchorSelector.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(28)))), ((int)(((byte)(28)))), ((int)(((byte)(28)))));
-        this.SpriteAnchorSelector.Font = new System.Drawing.Font("Segoe UI", 9F);
-        this.SpriteAnchorSelector.ForeColor = System.Drawing.Color.White;
-        this.SpriteAnchorSelector.Location = new System.Drawing.Point(0, 0);
-        this.SpriteAnchorSelector.Name = "SpriteAnchorSelector";
-        this.SpriteAnchorSelector.Size = new System.Drawing.Size(300, 289);
-        this.SpriteAnchorSelector.TabIndex = 1;
-        this.SpriteAnchorSelector.Text = "Sprite Anchor";
-        this.SpriteAnchorSelector.Visible = false;
+        SpriteAnchorSelector.AutoSize = true;
+        SpriteAnchorSelector.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        SpriteAnchorSelector.BackColor = Color.FromArgb(28, 28, 28);
+        SpriteAnchorSelector.Font = new Font("Segoe UI", 9F);
+        SpriteAnchorSelector.ForeColor = Color.White;
+        SpriteAnchorSelector.Location = new Point(3, 3);
+        SpriteAnchorSelector.Name = "SpriteAnchorSelector";
+        SpriteAnchorSelector.Size = new Size(197, 255);
+        SpriteAnchorSelector.TabIndex = 1;
+        SpriteAnchorSelector.Text = "Sprite Anchor";
+        SpriteAnchorSelector.Visible = false;
         // 
         // PanelImageViewControls
         // 
-        this.PanelImageViewControls.AutoSize = true;
-        this.PanelImageViewControls.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-        this.PanelImageViewControls.ColumnCount = 7;
-        this.PanelImageViewControls.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.PanelImageViewControls.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-        this.PanelImageViewControls.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.PanelImageViewControls.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.PanelImageViewControls.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.PanelImageViewControls.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-        this.PanelImageViewControls.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 16F));
-        this.PanelImageViewControls.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-        this.PanelImageViewControls.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-        this.PanelImageViewControls.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-        this.PanelImageViewControls.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-        this.PanelImageViewControls.Controls.Add(this.LabelSpriteInfo, 0, 0);
-        this.PanelImageViewControls.Controls.Add(this.LabelArrayIndexDetails, 4, 0);
-        this.PanelImageViewControls.Controls.Add(this.ButtonPrevArrayIndex, 3, 0);
-        this.PanelImageViewControls.Controls.Add(this.ButtonNextArrayIndex, 5, 0);
-        this.PanelImageViewControls.Controls.Add(this.LabelArrayIndex, 2, 0);
-        this.PanelImageViewControls.Dock = System.Windows.Forms.DockStyle.Fill;
-        this.PanelImageViewControls.Location = new System.Drawing.Point(0, 0);
-        this.PanelImageViewControls.MinimumSize = new System.Drawing.Size(0, 26);
-        this.PanelImageViewControls.Name = "PanelImageViewControls";
-        this.PanelImageViewControls.RowCount = 1;
-        this.PanelImageViewControls.RowStyles.Add(new System.Windows.Forms.RowStyle());
-        this.PanelImageViewControls.Size = new System.Drawing.Size(844, 26);
-        this.PanelImageViewControls.TabIndex = 2;
+        PanelImageViewControls.AutoSize = true;
+        PanelImageViewControls.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        PanelImageViewControls.ColumnCount = 7;
+        PanelImageViewControls.ColumnStyles.Add(new ColumnStyle());
+        PanelImageViewControls.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        PanelImageViewControls.ColumnStyles.Add(new ColumnStyle());
+        PanelImageViewControls.ColumnStyles.Add(new ColumnStyle());
+        PanelImageViewControls.ColumnStyles.Add(new ColumnStyle());
+        PanelImageViewControls.ColumnStyles.Add(new ColumnStyle());
+        PanelImageViewControls.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 16F));
+        PanelImageViewControls.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
+        PanelImageViewControls.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
+        PanelImageViewControls.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
+        PanelImageViewControls.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
+        PanelImageViewControls.Controls.Add(LabelSpriteInfo, 0, 0);
+        PanelImageViewControls.Controls.Add(LabelArrayIndexDetails, 4, 0);
+        PanelImageViewControls.Controls.Add(ButtonPrevArrayIndex, 3, 0);
+        PanelImageViewControls.Controls.Add(ButtonNextArrayIndex, 5, 0);
+        PanelImageViewControls.Controls.Add(LabelArrayIndex, 2, 0);
+        PanelImageViewControls.Dock = DockStyle.Fill;
+        PanelImageViewControls.Location = new Point(0, 0);
+        PanelImageViewControls.MinimumSize = new Size(0, 26);
+        PanelImageViewControls.Name = "PanelImageViewControls";
+        PanelImageViewControls.RowCount = 1;
+        PanelImageViewControls.RowStyles.Add(new RowStyle());
+        PanelImageViewControls.Size = new Size(712, 26);
+        PanelImageViewControls.TabIndex = 2;
         // 
         // LabelSpriteInfo
         // 
-        this.LabelSpriteInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-        | System.Windows.Forms.AnchorStyles.Left) 
-        | System.Windows.Forms.AnchorStyles.Right)));
-        this.LabelSpriteInfo.AutoSize = true;
-        this.LabelSpriteInfo.Location = new System.Drawing.Point(3, 0);
-        this.LabelSpriteInfo.Name = "LabelSpriteInfo";
-        this.LabelSpriteInfo.Size = new System.Drawing.Size(189, 28);
-        this.LabelSpriteInfo.TabIndex = 11;
-        this.LabelSpriteInfo.Text = "Sprite Dimenions: LxT - RxB (WxH)";
-        this.LabelSpriteInfo.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+        LabelSpriteInfo.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+        LabelSpriteInfo.AutoSize = true;
+        LabelSpriteInfo.Location = new Point(3, 0);
+        LabelSpriteInfo.Name = "LabelSpriteInfo";
+        LabelSpriteInfo.Size = new Size(189, 28);
+        LabelSpriteInfo.TabIndex = 11;
+        LabelSpriteInfo.Text = "Sprite Dimenions: LxT - RxB (WxH)";
+        LabelSpriteInfo.TextAlign = ContentAlignment.MiddleLeft;
         // 
         // LabelArrayIndexDetails
         // 
-        this.LabelArrayIndexDetails.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-        | System.Windows.Forms.AnchorStyles.Left) 
-        | System.Windows.Forms.AnchorStyles.Right)));
-        this.LabelArrayIndexDetails.AutoSize = true;
-        this.LabelArrayIndexDetails.Location = new System.Drawing.Point(742, 0);
-        this.LabelArrayIndexDetails.MinimumSize = new System.Drawing.Size(55, 0);
-        this.LabelArrayIndexDetails.Name = "LabelArrayIndexDetails";
-        this.LabelArrayIndexDetails.Size = new System.Drawing.Size(55, 28);
-        this.LabelArrayIndexDetails.TabIndex = 9;
-        this.LabelArrayIndexDetails.Text = "1/n";
-        this.LabelArrayIndexDetails.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+        LabelArrayIndexDetails.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+        LabelArrayIndexDetails.AutoSize = true;
+        LabelArrayIndexDetails.Location = new Point(610, 0);
+        LabelArrayIndexDetails.MinimumSize = new Size(55, 0);
+        LabelArrayIndexDetails.Name = "LabelArrayIndexDetails";
+        LabelArrayIndexDetails.Size = new Size(55, 28);
+        LabelArrayIndexDetails.TabIndex = 9;
+        LabelArrayIndexDetails.Text = "1/n";
+        LabelArrayIndexDetails.TextAlign = ContentAlignment.MiddleCenter;
         // 
         // ButtonPrevArrayIndex
         // 
-        this.ButtonPrevArrayIndex.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-        | System.Windows.Forms.AnchorStyles.Left) 
-        | System.Windows.Forms.AnchorStyles.Right)));
-        this.ButtonPrevArrayIndex.AutoSize = true;
-        this.ButtonPrevArrayIndex.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-        this.ButtonPrevArrayIndex.Enabled = false;
-        this.ButtonPrevArrayIndex.FlatAppearance.BorderSize = 0;
-        this.ButtonPrevArrayIndex.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Orange;
-        this.ButtonPrevArrayIndex.FlatAppearance.MouseOverBackColor = System.Drawing.Color.SteelBlue;
-        this.ButtonPrevArrayIndex.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-        this.ButtonPrevArrayIndex.Image = global::Gorgon.Editor.SpriteEditor.Properties.Resources.left_16x16;
-        this.ButtonPrevArrayIndex.Location = new System.Drawing.Point(714, 3);
-        this.ButtonPrevArrayIndex.Name = "ButtonPrevArrayIndex";
-        this.ButtonPrevArrayIndex.Size = new System.Drawing.Size(22, 22);
-        this.ButtonPrevArrayIndex.TabIndex = 8;
-        this.ButtonPrevArrayIndex.Click += new System.EventHandler(this.ButtonPrevArrayIndex_Click);
+        ButtonPrevArrayIndex.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+        ButtonPrevArrayIndex.AutoSize = true;
+        ButtonPrevArrayIndex.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        ButtonPrevArrayIndex.Enabled = false;
+        ButtonPrevArrayIndex.FlatAppearance.BorderSize = 0;
+        ButtonPrevArrayIndex.FlatAppearance.MouseDownBackColor = Color.Orange;
+        ButtonPrevArrayIndex.FlatAppearance.MouseOverBackColor = Color.SteelBlue;
+        ButtonPrevArrayIndex.FlatStyle = FlatStyle.Flat;
+        ButtonPrevArrayIndex.Image = Properties.Resources.left_16x16;
+        ButtonPrevArrayIndex.Location = new Point(582, 3);
+        ButtonPrevArrayIndex.Name = "ButtonPrevArrayIndex";
+        ButtonPrevArrayIndex.Size = new Size(22, 22);
+        ButtonPrevArrayIndex.TabIndex = 8;
+        ButtonPrevArrayIndex.Click += ButtonPrevArrayIndex_Click;
         // 
         // ButtonNextArrayIndex
         // 
-        this.ButtonNextArrayIndex.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-        | System.Windows.Forms.AnchorStyles.Left) 
-        | System.Windows.Forms.AnchorStyles.Right)));
-        this.ButtonNextArrayIndex.AutoSize = true;
-        this.ButtonNextArrayIndex.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-        this.ButtonNextArrayIndex.Enabled = false;
-        this.ButtonNextArrayIndex.FlatAppearance.BorderSize = 0;
-        this.ButtonNextArrayIndex.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Orange;
-        this.ButtonNextArrayIndex.FlatAppearance.MouseOverBackColor = System.Drawing.Color.SteelBlue;
-        this.ButtonNextArrayIndex.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-        this.ButtonNextArrayIndex.Image = global::Gorgon.Editor.SpriteEditor.Properties.Resources.right_16x16;
-        this.ButtonNextArrayIndex.Location = new System.Drawing.Point(803, 3);
-        this.ButtonNextArrayIndex.Name = "ButtonNextArrayIndex";
-        this.ButtonNextArrayIndex.Size = new System.Drawing.Size(22, 22);
-        this.ButtonNextArrayIndex.TabIndex = 10;
-        this.ButtonNextArrayIndex.Click += new System.EventHandler(this.ButtonNextArrayIndex_Click);
+        ButtonNextArrayIndex.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+        ButtonNextArrayIndex.AutoSize = true;
+        ButtonNextArrayIndex.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        ButtonNextArrayIndex.Enabled = false;
+        ButtonNextArrayIndex.FlatAppearance.BorderSize = 0;
+        ButtonNextArrayIndex.FlatAppearance.MouseDownBackColor = Color.Orange;
+        ButtonNextArrayIndex.FlatAppearance.MouseOverBackColor = Color.SteelBlue;
+        ButtonNextArrayIndex.FlatStyle = FlatStyle.Flat;
+        ButtonNextArrayIndex.Image = Properties.Resources.right_16x16;
+        ButtonNextArrayIndex.Location = new Point(671, 3);
+        ButtonNextArrayIndex.Name = "ButtonNextArrayIndex";
+        ButtonNextArrayIndex.Size = new Size(22, 22);
+        ButtonNextArrayIndex.TabIndex = 10;
+        ButtonNextArrayIndex.Click += ButtonNextArrayIndex_Click;
         // 
         // LabelArrayIndex
         // 
-        this.LabelArrayIndex.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-        | System.Windows.Forms.AnchorStyles.Left) 
-        | System.Windows.Forms.AnchorStyles.Right)));
-        this.LabelArrayIndex.AutoSize = true;
-        this.LabelArrayIndex.Location = new System.Drawing.Point(638, 0);
-        this.LabelArrayIndex.Name = "LabelArrayIndex";
-        this.LabelArrayIndex.Size = new System.Drawing.Size(70, 28);
-        this.LabelArrayIndex.TabIndex = 3;
-        this.LabelArrayIndex.Text = "Array index:";
-        this.LabelArrayIndex.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+        LabelArrayIndex.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+        LabelArrayIndex.AutoSize = true;
+        LabelArrayIndex.Location = new Point(506, 0);
+        LabelArrayIndex.Name = "LabelArrayIndex";
+        LabelArrayIndex.Size = new Size(70, 28);
+        LabelArrayIndex.TabIndex = 3;
+        LabelArrayIndex.Text = "Array index:";
+        LabelArrayIndex.TextAlign = ContentAlignment.MiddleLeft;
+        // 
+        // flowLayoutPanel1
+        // 
+        flowLayoutPanel1.AutoSize = true;
+        flowLayoutPanel1.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        flowLayoutPanel1.Controls.Add(SpriteAnchorSelector);
+        flowLayoutPanel1.Controls.Add(SpritePickMaskColor);
+        flowLayoutPanel1.Controls.Add(SpriteColorSelector);
+        flowLayoutPanel1.Controls.Add(SpriteWrapping);
+        flowLayoutPanel1.Dock = DockStyle.Fill;
+        flowLayoutPanel1.FlowDirection = FlowDirection.TopDown;
+        flowLayoutPanel1.Location = new Point(0, 0);
+        flowLayoutPanel1.Name = "flowLayoutPanel1";
+        flowLayoutPanel1.Size = new Size(395, 762);
+        flowLayoutPanel1.TabIndex = 4;
+        flowLayoutPanel1.WrapContents = false;
         // 
         // SpriteEditorView
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-        this.Name = "SpriteEditorView";
-        this.Size = new System.Drawing.Size(1237, 784);
-        this.StatusPanel.ResumeLayout(false);
-        this.StatusPanel.PerformLayout();
-        this.HostPanel.ResumeLayout(false);
-        this.HostPanel.PerformLayout();
-        this.HostPanelControls.ResumeLayout(false);
-        this.HostPanelControls.PerformLayout();
-        this.PanelImageViewControls.ResumeLayout(false);
-        this.PanelImageViewControls.PerformLayout();
-        this.ResumeLayout(false);
-        this.PerformLayout();
-
+        AutoScaleDimensions = new SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
+        Name = "SpriteEditorView";
+        Size = new Size(1108, 784);
+        StatusPanel.ResumeLayout(false);
+        StatusPanel.PerformLayout();
+        HostPanel.ResumeLayout(false);
+        HostPanel.PerformLayout();
+        HostPanelControls.ResumeLayout(false);
+        HostPanelControls.PerformLayout();
+        PanelImageViewControls.ResumeLayout(false);
+        PanelImageViewControls.PerformLayout();
+        flowLayoutPanel1.ResumeLayout(false);
+        flowLayoutPanel1.PerformLayout();
+        ResumeLayout(false);
+        PerformLayout();
     }
-
 
     private System.Windows.Forms.TableLayoutPanel PanelImageViewControls;
     private System.Windows.Forms.Label LabelSpriteInfo;
@@ -321,4 +331,5 @@ partial class SpriteEditorView
     private SpriteAnchor SpriteAnchorSelector;
     private SpritePickMaskColor SpritePickMaskColor;
     private SpriteWrap SpriteWrapping;
+    private FlowLayoutPanel flowLayoutPanel1;
 }

--- a/PlugIns/Gorgon.Editor.SpriteEditor/_Internal/Views/SpriteEditorView.resx
+++ b/PlugIns/Gorgon.Editor.SpriteEditor/_Internal/Views/SpriteEditorView.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/Tools/Editor/Gorgon.Editor.API/UI/Controls/AlphaPicker.Designer.cs
+++ b/Tools/Editor/Gorgon.Editor.API/UI/Controls/AlphaPicker.Designer.cs
@@ -122,8 +122,8 @@ partial class AlphaPicker
         // 
         // AlphaPicker
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(35)))), ((int)(((byte)(35)))), ((int)(((byte)(37)))));
         this.Controls.Add(this.TableAlpha);
         

--- a/Tools/Editor/Gorgon.Editor.API/UI/Controls/ColorPicker.Designer.cs
+++ b/Tools/Editor/Gorgon.Editor.API/UI/Controls/ColorPicker.Designer.cs
@@ -34,40 +34,38 @@ partial class ColorPicker
     /// </summary>
     private void InitializeComponent()
     {
-            this.Picker = new Fetze.WinFormsColor.ColorPickerPanel();
-            this.SuspendLayout();
-            // 
-            // Picker
-            // 
-            this.Picker.AlphaEnabled = true;
-            this.Picker.AutoSize = true;
-            this.Picker.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.Picker.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Picker.Location = new System.Drawing.Point(0, 0);
-            this.Picker.MinimumSize = new System.Drawing.Size(360, 288);
-            this.Picker.Name = "Picker";
-            this.Picker.OldColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.Picker.PrimaryAttribute = Fetze.WinFormsColor.ColorPickerPanel.PrimaryAttrib.Hue;
-            this.Picker.SelectedColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.Picker.Size = new System.Drawing.Size(418, 306);
-            this.Picker.TabIndex = 0;
-            this.Picker.ColorChanged += new System.EventHandler(this.Picker_ColorChanged);
-            this.Picker.OldColorChanged += new System.EventHandler(this.Picker_ColorChanged);
-            // 
-            // ColorPicker
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.Picker);
-            
-            this.Name = "GorgonColorPicker";
-            this.Size = new System.Drawing.Size(418, 306);
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+        Picker = new Fetze.WinFormsColor.ColorPickerPanel();
+        SuspendLayout();
+        // 
+        // Picker
+        // 
+        Picker.AlphaEnabled = true;
+        Picker.AutoSize = true;
+        Picker.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        Picker.Dock = DockStyle.Fill;
+        Picker.Location = new Point(0, 0);
+        Picker.MinimumSize = new Size(360, 288);
+        Picker.Name = "Picker";
+        Picker.OldColor = Color.FromArgb(255, 0, 0);
+        Picker.PrimaryAttribute = Fetze.WinFormsColor.ColorPickerPanel.PrimaryAttrib.Hue;
+        Picker.SelectedColor = Color.FromArgb(255, 0, 0);
+        Picker.Size = new Size(360, 288);
+        Picker.TabIndex = 0;
+        Picker.ColorChanged += Picker_ColorChanged;
+        Picker.OldColorChanged += Picker_ColorChanged;
+        // 
+        // ColorPicker
+        // 
+        AutoScaleDimensions = new SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
+        AutoSize = true;
+        AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        Controls.Add(Picker);
+        Name = "ColorPicker";
+        Size = new Size(360, 288);
+        ResumeLayout(false);
+        PerformLayout();
     }
-
-
 
     private Fetze.WinFormsColor.ColorPickerPanel Picker;
 }

--- a/Tools/Editor/Gorgon.Editor.API/UI/Controls/ColorPicker.resx
+++ b/Tools/Editor/Gorgon.Editor.API/UI/Controls/ColorPicker.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/Tools/Editor/Gorgon.Editor.API/UI/Controls/ContentFileExplorer.Designer.cs
+++ b/Tools/Editor/Gorgon.Editor.API/UI/Controls/ContentFileExplorer.Designer.cs
@@ -231,8 +231,8 @@ partial class ContentFileExplorer
         // 
         // ContentFileExplorer
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.Controls.Add(this.LabelNoFiles);
         this.Controls.Add(this.tableLayoutPanel1);
         this.Name = "ContentFileExplorer";

--- a/Tools/Editor/Gorgon.Editor.API/UI/Views/ContentBaseControl.cs
+++ b/Tools/Editor/Gorgon.Editor.API/UI/Views/ContentBaseControl.cs
@@ -410,66 +410,72 @@ public partial class ContentBaseControl
             throw new ArgumentNullException(nameof(control));
         }
 
-        Control hostParent = PanelHostControls;
+        control.Visible = true;
 
-        try
-        {
-            while (hostParent is not null)
-            {
-                hostParent.SuspendLayout();
-                hostParent = hostParent.Parent;
-            }
+        PanelHostControls.Visible = PanelHost.Visible = true;
 
-            control.SuspendLayout();
+        CurrentHostedPanel = control;
 
-            foreach (Control hostControl in PanelHostControls.Controls.OfType<Control>().Where(item => item != control))
-            {
-                hostControl.Visible = false;
-            }
+        ////Control hostParent = PanelHostControls;
 
-            control.Left = 0;
-            control.Top = 0;
-            float dpiScale = 1;
-            int maxSize = ClientSize.Width - (Margin.Left + Margin.Right);
+        ////try
+        ////{
+        ////    while (hostParent is not null)
+        ////    {
+        ////        hostParent.SuspendLayout();
+        ////        hostParent = hostParent.Parent;
+        ////    }
 
-            if (DeviceDpi != 96)
-            {
-                dpiScale = DeviceDpi / 96.0f;
-            }
+        ////    control.SuspendLayout();
 
-            // Our control width should be within this range.  
-            if (control.Width > maxSize)
-            {
-                control.Width = maxSize;
-            }
+        ////    foreach (Control hostControl in PanelHostControls.Controls.OfType<Control>().Where(item => item != control))
+        ////    {
+        ////        hostControl.Visible = false;
+        ////    }
 
-            if (control.Width < (int)(300 * dpiScale).FastFloor())
-            {
-                control.Width = (int)(300 * dpiScale).FastFloor();
-            }
+        ////    control.Left = 0;
+        ////    control.Top = 0;
+        ////    float dpiScale = 1;
+        ////    int maxSize = ClientSize.Width - (Margin.Left + Margin.Right);
 
-            int newWidth = control.Width + PanelHost.Padding.Left;
-            if (control.Height > PanelHostControls.ClientSize.Height)
-            {
-                newWidth += SystemInformation.VerticalScrollBarWidth;
-            }
+        ////    if (DeviceDpi != 96)
+        ////    {
+        ////        dpiScale = DeviceDpi / 96.0f;
+        ////    }
 
-            PanelHost.Width = newWidth;
-            PanelHostControls.Visible = PanelHost.Visible = true;
-            control.Visible = true;
-            PanelHostControls.AutoScrollMinSize = new Size(0, control.Height);
+        ////    // Our control width should be within this range.  
+        ////    if (control.Width > maxSize)
+        ////    {
+        ////        control.Width = maxSize;
+        ////    }
 
-            CurrentHostedPanel = control;
-        }
-        finally
-        {
-            hostParent = control;
-            while (hostParent is not null)
-            {
-                hostParent.ResumeLayout();
-                hostParent = hostParent.Parent;
-            }
-        }
+        ////    if (control.Width < (int)(300 * dpiScale).FastFloor())
+        ////    {
+        ////        control.Width = (int)(300 * dpiScale).FastFloor();
+        ////    }
+
+        ////    int newWidth = control.Width + PanelHost.Padding.Left;
+        ////    if (control.Height > PanelHostControls.ClientSize.Height)
+        ////    {
+        ////        newWidth += SystemInformation.VerticalScrollBarWidth;
+        ////    }
+
+        ////    PanelHost.Width = newWidth;
+        ////    PanelHostControls.Visible = PanelHost.Visible = true;
+        ////    control.Visible = true;
+        ////    PanelHostControls.AutoScrollMinSize = new Size(0, control.Height);
+
+        ////    CurrentHostedPanel = control;
+        ////}
+        ////finally
+        ////{
+        ////    hostParent = control;
+        ////    while (hostParent is not null)
+        ////    {
+        ////        hostParent.ResumeLayout();
+        ////        hostParent = hostParent.Parent;
+        ////    }
+        ////}
     }
 
     /// <summary>

--- a/Tools/Editor/Gorgon.Editor.API/UI/Views/EditorToolBaseForm.Designer.cs
+++ b/Tools/Editor/Gorgon.Editor.API/UI/Views/EditorToolBaseForm.Designer.cs
@@ -39,7 +39,7 @@ partial class EditorToolBaseForm
         // 
         // EditorToolBaseForm
         // 
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(28)))), ((int)(((byte)(28)))), ((int)(((byte)(28)))));
         this.ClientSize = new System.Drawing.Size(784, 561);
         

--- a/Tools/Editor/Gorgon.Editor.API/UI/_Internal/FormSaveDialog.Designer.cs
+++ b/Tools/Editor/Gorgon.Editor.API/UI/_Internal/FormSaveDialog.Designer.cs
@@ -151,8 +151,8 @@ partial class FormSaveDialog
         // FormSaveDialog
         // 
         this.AcceptButton = this.ButtonOK;
-        this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(28)))), ((int)(((byte)(28)))), ((int)(((byte)(28)))));
         this.CancelButton = this.ButtonCancel;
         this.ClientSize = new System.Drawing.Size(592, 497);

--- a/Tools/Editor/Gorgon.Editor/FormSplash.designer.cs
+++ b/Tools/Editor/Gorgon.Editor/FormSplash.designer.cs
@@ -130,8 +130,8 @@ namespace Gorgon.Editor;
         // 
         // FormSplash
         // 
-        AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-        AutoScaleMode = AutoScaleMode.Dpi;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
         BackColor = System.Drawing.Color.White;
         BackgroundImageLayout = ImageLayout.Center;
         ClientSize = new System.Drawing.Size(621, 158);


### PR DESCRIPTION
You are very lucky because I needed a bit distraction from a very inconvenient task 😆 

Here's a brief explanation of the changes;

### General

- Autoscaling was totally messed up. Use AutoScalemode.Font everywhere. Especially, mixing of dpi and font scaling is a recipe for trouble
- When you have autoscalemode set to Font, you can easily test in the designer what will happen when a control  gets scaled: Just change the font size of your control (e.g. ColorPickerPanel) to 12 or 14
- Do you happen to work on a monitor to which a scaling is applied (Windows > Settings > Display ?
  If yes: screw that. You cannot do proper WinForms development with a scaled display.
- There are still issues with scaling, but those are in the components you are using and need to be fixed there (e.g. ribbon)

### ColorPickerPanel

- The radio buttons are autosized, which means the size depends on the text. The letters HSV... have different widths. That's why the cannot be anchored right. Only when anchrored left, you will have the radio icons in-line vertically
- I would avoid border-style fixed, because this causes the control to draw the border itself and it's not drawn by the the OS theme 
  (even though the NumericUpDown is a very bad example because they haven't updated it and it's never drawn themed)
- AutoSize is a very very tricky thing. It's find for labels, radios or other single controls. But I wouldn't recommend to use it on container controls - unless you know exactly how it works and you have some deep experience with it. Otherwise, you are just calling for trouble
- I've reset the margins (not needed) and added some horizontal ones
- When looking at the diff, don't get yourself confused by the different Location and Size properties. You can  ignore these because they are coming from autosizing and margin changes. You cannot manually move the controls at alll

Hope it helps,
sw
